### PR TITLE
Fix publish ordering for multiple messages (#57)

### DIFF
--- a/src/commands/channels/publish.ts
+++ b/src/commands/channels/publish.ts
@@ -55,7 +55,6 @@ export default class ChannelsPublish extends AblyBaseCommand {
       description: "The event name (if not specified in the message JSON)",
     }),
     transport: Flags.string({
-      default: "rest",
       description: "Transport method to use for publishing (rest or realtime)",
       options: ["rest", "realtime"],
     }),
@@ -88,8 +87,10 @@ export default class ChannelsPublish extends AblyBaseCommand {
     const { args, flags } = await this.parse(ChannelsPublish);
 
     // Use Realtime transport by default when publishing multiple messages to ensure ordering
+    // If transport is not explicitly set and count > 1, use realtime
+    // If transport is explicitly set, respect that choice
     const shouldUseRealtime = flags.transport === "realtime" || 
-      (flags.transport !== "rest" && flags.count > 1);
+      (!flags.transport && flags.count > 1);
     
     await (shouldUseRealtime
       ? this.publishWithRealtime(args, flags)

--- a/src/commands/rooms/messages/send.ts
+++ b/src/commands/rooms/messages/send.ts
@@ -62,9 +62,9 @@ export default class MessagesSend extends ChatBaseCommand {
     }),
     delay: Flags.integer({
       char: "d",
-      default: 0,
+      default: 40,
       description:
-        "Delay between messages in milliseconds (min 10ms when count > 1)",
+        "Delay between messages in milliseconds (default: 40ms, max 25 msgs/sec)",
     }),
     metadata: Flags.string({
       description: "Additional metadata for the message (JSON format)",
@@ -220,13 +220,13 @@ export default class MessagesSend extends ChatBaseCommand {
       let { delay } = flags;
 
       // Enforce minimum delay when sending multiple messages
-      if (count > 1 && delay < 10) {
-        delay = 10;
+      if (count > 1 && delay < 40) {
+        delay = 40;
         this.logCliEvent(
           flags,
           "message",
           "minDelayEnforced",
-          "Using minimum delay of 10ms for multiple messages",
+          "Using minimum delay of 40ms for multiple messages",
           { delay },
         );
       }

--- a/test/integration/commands/channels-publish-ordering.test.ts
+++ b/test/integration/commands/channels-publish-ordering.test.ts
@@ -1,0 +1,210 @@
+import { expect } from "chai";
+import { test } from "@oclif/test";
+
+describe('Channels publish ordering integration tests', function() {
+  let originalEnv: NodeJS.ProcessEnv;
+  let publishedMessages: Array<{ data: string; timestamp: number }>;
+  let realtimeConnectionUsed: boolean;
+
+  beforeEach(function() {
+    // Store original env vars
+    originalEnv = { ...process.env };
+    publishedMessages = [];
+    realtimeConnectionUsed = false;
+
+    // Create a function that tracks published messages with timestamps
+    const publishFunction = async (message: any) => {
+      publishedMessages.push({
+        data: message.data,
+        timestamp: Date.now()
+      });
+      // Simulate some network latency
+      await new Promise(resolve => setTimeout(resolve, Math.random() * 10));
+      return;
+    };
+
+    // Create mock Ably clients
+    const mockRealtimeClient = {
+      channels: {
+        get: () => ({
+          publish: publishFunction
+        })
+      },
+      connection: {
+        once: (event: string, callback: () => void) => {
+          realtimeConnectionUsed = true;
+          if (event === 'connected') {
+            setTimeout(callback, 0);
+          }
+        },
+        on: () => {},
+        state: 'connected'
+      },
+      close: () => {}
+    };
+
+    const mockRestClient = {
+      channels: {
+        get: () => ({
+          publish: publishFunction
+        })
+      }
+    };
+
+    // Make the mocks globally available
+    globalThis.__TEST_MOCKS__ = {
+      ablyRealtimeMock: mockRealtimeClient,
+      ablyRestMock: mockRestClient
+    };
+
+    process.env.ABLY_TEST_MODE = 'true';
+    process.env.ABLY_SUPPRESS_PROCESS_EXIT = 'true';
+    process.env.ABLY_KEY = 'test_key';
+  });
+
+  afterEach(function() {
+    process.env = originalEnv;
+    delete globalThis.__TEST_MOCKS__;
+  });
+
+  describe('Multiple message publishing', function() {
+    it('should use realtime transport by default when publishing multiple messages', function() {
+      return test
+        .stdout()
+        .command(['channels:publish', 'test-channel', 'Message {{.Count}}', '--count', '3'])
+        .it('uses realtime transport for multiple messages', ctx => {
+          expect(ctx.stdout).to.include('3/3 messages published successfully');
+          // Should have used realtime connection
+          expect(realtimeConnectionUsed).to.be.true;
+        });
+    });
+
+    it('should respect explicit rest transport flag', function() {
+      return test
+        .stdout()
+        .command(['channels:publish', 'test-channel', 'Message {{.Count}}', '--count', '3', '--transport', 'rest'])
+        .it('uses rest transport when explicitly specified', ctx => {
+          expect(ctx.stdout).to.include('3/3 messages published successfully');
+          // Should not have used realtime connection
+          expect(realtimeConnectionUsed).to.be.false;
+        });
+    });
+
+    it('should use rest transport for single message by default', function() {
+      return test
+        .stdout()
+        .command(['channels:publish', 'test-channel', 'Single message'])
+        .it('uses rest transport for single message', ctx => {
+          expect(ctx.stdout).to.include('Message published successfully');
+          // Should not have used realtime connection
+          expect(realtimeConnectionUsed).to.be.false;
+        });
+    });
+  });
+
+  describe('Message delay and ordering', function() {
+    it('should have 40ms default delay between messages', function() {
+      const startTime = Date.now();
+      return test
+        .stdout()
+        .command(['channels:publish', 'test-channel', 'Message {{.Count}}', '--count', '3'])
+        .it('applies default 40ms delay', ctx => {
+          expect(ctx.stdout).to.include('Publishing 3 messages with 40ms delay');
+          expect(ctx.stdout).to.include('3/3 messages published successfully');
+          
+          // Check that messages were published with appropriate delays
+          expect(publishedMessages).to.have.lengthOf(3);
+          
+          // Check message order
+          expect(publishedMessages[0].data).to.equal('Message 1');
+          expect(publishedMessages[1].data).to.equal('Message 2');
+          expect(publishedMessages[2].data).to.equal('Message 3');
+          
+          // Check timing - should take at least 80ms (2 delays of 40ms)
+          const totalTime = Date.now() - startTime;
+          expect(totalTime).to.be.at.least(80);
+        });
+    });
+
+    it('should respect custom delay value', function() {
+      const startTime = Date.now();
+      return test
+        .stdout()
+        .command(['channels:publish', 'test-channel', 'Message {{.Count}}', '--count', '3', '--delay', '100'])
+        .it('applies custom delay', ctx => {
+          expect(ctx.stdout).to.include('Publishing 3 messages with 100ms delay');
+          expect(ctx.stdout).to.include('3/3 messages published successfully');
+          
+          // Check timing - should take at least 200ms (2 delays of 100ms)
+          const totalTime = Date.now() - startTime;
+          expect(totalTime).to.be.at.least(200);
+        });
+    });
+
+    it('should allow zero delay when explicitly set', function() {
+      return test
+        .stdout()
+        .command(['channels:publish', 'test-channel', 'Message {{.Count}}', '--count', '3', '--delay', '0'])
+        .it('allows zero delay when explicit', ctx => {
+          expect(ctx.stdout).to.include('Publishing 3 messages with 0ms delay');
+          expect(ctx.stdout).to.include('3/3 messages published successfully');
+        });
+    });
+
+    it('should publish messages in sequential order with delay', function() {
+      return test
+        .stdout()
+        .command(['channels:publish', 'test-channel', 'Message {{.Count}}', '--count', '5'])
+        .it('maintains message order', _ctx => {
+          expect(publishedMessages).to.have.lengthOf(5);
+          
+          // Verify messages are in correct order
+          for (let i = 0; i < 5; i++) {
+            expect(publishedMessages[i].data).to.equal(`Message ${i + 1}`);
+          }
+          
+          // Verify timestamps are sequential (each should be at least 40ms apart)
+          for (let i = 1; i < publishedMessages.length; i++) {
+            const timeDiff = publishedMessages[i].timestamp - publishedMessages[i - 1].timestamp;
+            expect(timeDiff).to.be.at.least(35); // Allow some margin for timer precision
+          }
+        });
+    });
+  });
+
+  describe('Error handling with multiple messages', function() {
+    it('should continue publishing remaining messages on error', function() {
+      // Override the publish function to make the 3rd message fail
+      let callCount = 0;
+      const failingPublishFunction = async (message: any) => {
+        callCount++;
+        if (callCount === 3) {
+          throw new Error('Network error');
+        }
+        publishedMessages.push({
+          data: message.data,
+          timestamp: Date.now()
+        });
+        return;
+      };
+      
+      // Update both mocks to use the failing function
+      if (globalThis.__TEST_MOCKS__) {
+        globalThis.__TEST_MOCKS__.ablyRealtimeMock.channels.get = () => ({
+          publish: failingPublishFunction
+        });
+        globalThis.__TEST_MOCKS__.ablyRestMock.channels.get = () => ({
+          publish: failingPublishFunction
+        });
+      }
+
+      return test
+        .stdout()
+        .command(['channels:publish', 'test-channel', 'Message {{.Count}}', '--count', '5'])
+        .it('handles errors gracefully', ctx => {
+          expect(ctx.stdout).to.include('4/5 messages published successfully (1 errors)');
+          expect(publishedMessages).to.have.lengthOf(4);
+        });
+    });
+  });
+});

--- a/test/integration/commands/rooms-messages-ordering.test.ts
+++ b/test/integration/commands/rooms-messages-ordering.test.ts
@@ -1,0 +1,187 @@
+import { expect } from "chai";
+import { test } from "@oclif/test";
+
+describe('Rooms messages send ordering integration tests', function() {
+  let originalEnv: NodeJS.ProcessEnv;
+  let sentMessages: Array<{ text: string; timestamp: number }>;
+  let sendFunction: (message: any) => Promise<void>;
+
+  beforeEach(function() {
+    // Store original env vars
+    originalEnv = { ...process.env };
+    sentMessages = [];
+
+    // Create a function that tracks sent messages with timestamps
+    sendFunction = async (message: any) => {
+      sentMessages.push({
+        text: message.text,
+        timestamp: Date.now()
+      });
+      // Simulate some network latency
+      await new Promise(resolve => setTimeout(resolve, Math.random() * 10));
+      return;
+    };
+
+    // Create mock Chat client
+    const mockChatClient = {
+      rooms: {
+        get: () => ({
+          attach: async () => {},
+          messages: {
+            send: sendFunction
+          }
+        }),
+        release: async () => {}
+      }
+    };
+
+    const mockAblyClient = {
+      connection: {
+        on: () => {},
+        state: 'connected'
+      },
+      close: () => {}
+    };
+
+    // Make the mocks globally available
+    globalThis.__TEST_MOCKS__ = {
+      ablyRestMock: {}, // Required by base type
+      ablyChatMock: mockChatClient,
+      ablyRealtimeMock: mockAblyClient
+    };
+
+    process.env.ABLY_TEST_MODE = 'true';
+    process.env.ABLY_SUPPRESS_PROCESS_EXIT = 'true';
+    process.env.ABLY_KEY = 'test_key';
+  });
+
+  afterEach(function() {
+    process.env = originalEnv;
+    delete globalThis.__TEST_MOCKS__;
+  });
+
+  describe('Message delay and ordering', function() {
+    it('should have 40ms default delay between messages', function() {
+      const startTime = Date.now();
+      return test
+        .stdout()
+        .command(['rooms:messages:send', 'test-room', 'Message {{.Count}}', '--count', '3'])
+        .it('applies default 40ms delay', ctx => {
+          expect(ctx.stdout).to.include('Sending 3 messages with 40ms delay');
+          expect(ctx.stdout).to.include('3/3 messages sent successfully');
+          
+          // Check that messages were sent with appropriate delays
+          expect(sentMessages).to.have.lengthOf(3);
+          
+          // Check message order
+          expect(sentMessages[0].text).to.equal('Message 1');
+          expect(sentMessages[1].text).to.equal('Message 2');
+          expect(sentMessages[2].text).to.equal('Message 3');
+          
+          // Check timing - should take at least 80ms (2 delays of 40ms)
+          const totalTime = Date.now() - startTime;
+          expect(totalTime).to.be.at.least(80);
+        });
+    });
+
+    it('should respect custom delay value', function() {
+      const startTime = Date.now();
+      return test
+        .stdout()
+        .command(['rooms:messages:send', 'test-room', 'Message {{.Count}}', '--count', '3', '--delay', '100'])
+        .it('applies custom delay', ctx => {
+          expect(ctx.stdout).to.include('Sending 3 messages with 100ms delay');
+          expect(ctx.stdout).to.include('3/3 messages sent successfully');
+          
+          // Check timing - should take at least 200ms (2 delays of 100ms)
+          const totalTime = Date.now() - startTime;
+          expect(totalTime).to.be.at.least(200);
+        });
+    });
+
+    it('should enforce minimum 40ms delay even if lower value specified', function() {
+      const startTime = Date.now();
+      return test
+        .stdout()
+        .command(['rooms:messages:send', 'test-room', 'Message {{.Count}}', '--count', '3', '--delay', '10'])
+        .it('enforces minimum delay', ctx => {
+          // Should use 40ms instead of 10ms
+          expect(ctx.stdout).to.include('Sending 3 messages with 40ms delay');
+          expect(ctx.stdout).to.include('3/3 messages sent successfully');
+          
+          // Check timing - should take at least 80ms (2 delays of 40ms)
+          const totalTime = Date.now() - startTime;
+          expect(totalTime).to.be.at.least(80);
+        });
+    });
+
+    it('should send messages in sequential order with delay', function() {
+      return test
+        .stdout()
+        .command(['rooms:messages:send', 'test-room', 'Message {{.Count}}', '--count', '5'])
+        .it('maintains message order', _ctx => {
+          expect(sentMessages).to.have.lengthOf(5);
+          
+          // Verify messages are in correct order
+          for (let i = 0; i < 5; i++) {
+            expect(sentMessages[i].text).to.equal(`Message ${i + 1}`);
+          }
+          
+          // Verify timestamps are sequential (each should be at least 40ms apart)
+          for (let i = 1; i < sentMessages.length; i++) {
+            const timeDiff = sentMessages[i].timestamp - sentMessages[i - 1].timestamp;
+            expect(timeDiff).to.be.at.least(35); // Allow some margin for timer precision
+          }
+        });
+    });
+  });
+
+  describe('Single message sending', function() {
+    it('should send single message without delay', function() {
+      return test
+        .stdout()
+        .command(['rooms:messages:send', 'test-room', 'Single message'])
+        .it('sends single message immediately', ctx => {
+          expect(ctx.stdout).to.include('Message sent successfully');
+          expect(sentMessages).to.have.lengthOf(1);
+          expect(sentMessages[0].text).to.equal('Single message');
+        });
+    });
+  });
+
+  describe('Error handling with multiple messages', function() {
+    it('should continue sending remaining messages on error', function() {
+      // Override the send function to make the 3rd message fail
+      let callCount = 0;
+      const failingSendFunction = async (message: any) => {
+        callCount++;
+        if (callCount === 3) {
+          throw new Error('Network error');
+        }
+        sentMessages.push({
+          text: message.text,
+          timestamp: Date.now()
+        });
+        return;
+      };
+      
+      // Update the mock to use the failing function
+      if (globalThis.__TEST_MOCKS__?.ablyChatMock) {
+        globalThis.__TEST_MOCKS__.ablyChatMock.rooms.get = () => ({
+          attach: async () => {},
+          messages: {
+            send: failingSendFunction
+          }
+        });
+      }
+
+      return test
+        .stdout()
+        .command(['rooms:messages:send', 'test-room', 'Message {{.Count}}', '--count', '5'])
+        .it('handles errors gracefully', ctx => {
+          expect(ctx.stdout).to.include('4/5 messages sent successfully (1 errors)');
+          expect(sentMessages).to.have.lengthOf(4);
+        });
+    });
+  });
+});


### PR DESCRIPTION
- Use realtime transport by default when publishing multiple messages to ensure ordering
- Add 40ms default delay between messages (max 25 msgs/sec) for both channels and rooms
- Fix channels publish to await each message sequentially when delay is specified
- Add comprehensive test coverage for ordering behavior

This ensures messages are published in the correct order when using `{{.Count}}` templates or other sequential operations.

Fixes https://github.com/ably/cli/issues/57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration tests to verify message ordering, delay, transport selection, and error handling for both channel publishing and room message sending commands.

* **Bug Fixes**
  * Improved error handling so that publishing or sending continues even if an error occurs with one message, with accurate reporting of successes and failures.

* **Style**
  * Updated default delay between messages to 40ms for both channel publishing and room message sending, with clearer flag descriptions and enforced minimum delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->