### PR TITLE
[WEB-4468] Expose CLI splitscreen operations outside of component

### DIFF
--- a/packages/react-web-cli/package.json
+++ b/packages/react-web-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/react-web-cli",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "React component for embedding the Ably CLI in a web terminal",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react-web-cli/src/AblyCliTerminal.test.tsx
+++ b/packages/react-web-cli/src/AblyCliTerminal.test.tsx
@@ -105,6 +105,7 @@ vi.mock('@xterm/addon-fit', () => ({
 // Now import the modules AFTER mocks are defined
 import * as GlobalReconnect from './global-reconnect';
 import { AblyCliTerminal } from './AblyCliTerminal'; // Import now
+import type { AblyCliTerminalHandle } from './AblyCliTerminal';
 import * as TerminalBoxModule from './terminal-box'; // Import to access mocked colours if needed for assertions
 
 // Mock use-terminal-visibility
@@ -1164,6 +1165,42 @@ describe('AblyCliTerminal - Connection Status and Animation', () => {
     
     // Split button should not be present
     expect(screen.queryByRole('button', { name: /Split terminal/i })).toBeNull();
+  });
+
+  test('imperative handle can toggle split-screen externally when enabled', async () => {
+    const ref = React.createRef<AblyCliTerminalHandle>();
+
+    render(
+      <AblyCliTerminal
+        ref={ref}
+        websocketUrl="wss://web-cli.ably.com"
+        ablyAccessToken="test-token"
+        ablyApiKey="test-key"
+        enableSplitScreen={true}
+        showSplitControl={false}
+      />
+    );
+
+    // Initially, no secondary container
+    expect(screen.queryByTestId('terminal-container-secondary')).toBeNull();
+
+    // Use imperative API to enable split
+    await act(async () => {
+      ref.current?.enableSplitScreen();
+      await Promise.resolve();
+    });
+
+    // Secondary pane should appear
+    expect(await screen.findByTestId('terminal-container-secondary')).toBeInTheDocument();
+
+    // Toggle back via imperative API
+    await act(async () => {
+      ref.current?.toggleSplitScreen();
+      await Promise.resolve();
+    });
+
+    // Secondary pane should be gone
+    expect(screen.queryByTestId('terminal-container-secondary')).toBeNull();
   });
 
   // -------------------------------------------------------------

--- a/packages/react-web-cli/src/index.ts
+++ b/packages/react-web-cli/src/index.ts
@@ -1,3 +1,3 @@
 export { AblyCliTerminal } from "./AblyCliTerminal.js";
-export type { AblyCliTerminalProps } from "./AblyCliTerminal.js";
+export type { AblyCliTerminalProps, AblyCliTerminalHandle } from "./AblyCliTerminal.js";
 export { useTerminalVisibility } from "./use-terminal-visibility.js";


### PR DESCRIPTION
We have the means to toggle splitscreen functionality on the web CLI via an internal component button, but in order to integrate the CLI more natively into the dashboard, ideally we should also be able to trigger this functionality from outside of the component as well. This PR facilitates this via methods exposed on the ref.

https://github.com/user-attachments/assets/f61b4612-8cc5-42bf-aa3c-54436d188109

The web example shows both an external trigger and an internal trigger. In reality we wouldn't want both, so one can set `showSplitControl` on `AblyCliTerminal` to false when external triggers are used to continue to allow splitscreen functionality, but to hide the button.

In addition, the react-web-cli version has been bumped to 0.8.0 to mark this and other work added between 0.7.2 and now.

### Word of bot
This pull request introduces an imperative API for controlling split-screen functionality in the `AblyCliTerminal` React component, allowing external components to programmatically enable, disable, or toggle split-screen mode. It also adds a new prop to hide the built-in split control button when split is managed externally. The example app and tests are updated to demonstrate and verify these new capabilities. The package version is bumped to 0.8.0.

**Imperative Split-Screen API and Component Enhancements:**

* `AblyCliTerminal` now supports an imperative handle (`AblyCliTerminalHandle`) via `forwardRef`, exposing methods such as `enableSplitScreen`, `disableSplitScreen`, `toggleSplitScreen`, `setSplitPosition`, and `getSplitState` for programmatic split control. [[1]](diffhunk://#diff-e1cf01b065456fa514d0dc8410052211dcba9c7a8c1709d615018a30748ac0b8R99-R116) [[2]](diffhunk://#diff-e1cf01b065456fa514d0dc8410052211dcba9c7a8c1709d615018a30748ac0b8L117-R135) [[3]](diffhunk://#diff-e1cf01b065456fa514d0dc8410052211dcba9c7a8c1709d615018a30748ac0b8L128-R147) [[4]](diffhunk://#diff-e1cf01b065456fa514d0dc8410052211dcba9c7a8c1709d615018a30748ac0b8R249-R282) [[5]](diffhunk://#diff-e1cf01b065456fa514d0dc8410052211dcba9c7a8c1709d615018a30748ac0b8R2828-R2829) [[6]](diffhunk://#diff-36a687f738de541c455470cca70a9ba504120d195de1d8cb4c07e439af302bc6L2-R2)
* Added a new prop, `showSplitControl`, to `AblyCliTerminal`, allowing consumers to hide the internal split-screen toggle button when managing split externally. [[1]](diffhunk://#diff-e1cf01b065456fa514d0dc8410052211dcba9c7a8c1709d615018a30748ac0b8R99-R116) [[2]](diffhunk://#diff-e1cf01b065456fa514d0dc8410052211dcba9c7a8c1709d615018a30748ac0b8L128-R147) [[3]](diffhunk://#diff-e1cf01b065456fa514d0dc8410052211dcba9c7a8c1709d615018a30748ac0b8L2646-R2700)

**Example App Updates:**

* Updated `examples/web-cli/src/App.tsx` to use the imperative split-screen API, including a new "Toggle Split" button that calls the imperative method on the terminal ref. [[1]](diffhunk://#diff-caa963b2b86f08ed5d90d5449dfc787e4a1374f2d09b97886e71e7cdbe3cfc25L1-R2) [[2]](diffhunk://#diff-caa963b2b86f08ed5d90d5449dfc787e4a1374f2d09b97886e71e7cdbe3cfc25R224-R228) [[3]](diffhunk://#diff-caa963b2b86f08ed5d90d5449dfc787e4a1374f2d09b97886e71e7cdbe3cfc25R237) [[4]](diffhunk://#diff-caa963b2b86f08ed5d90d5449dfc787e4a1374f2d09b97886e71e7cdbe3cfc25R261-R267)
* Removed unused custom auth state logic for code clarity. [[1]](diffhunk://#diff-caa963b2b86f08ed5d90d5449dfc787e4a1374f2d09b97886e71e7cdbe3cfc25L125-R125) [[2]](diffhunk://#diff-caa963b2b86f08ed5d90d5449dfc787e4a1374f2d09b97886e71e7cdbe3cfc25L188-R188) [[3]](diffhunk://#diff-caa963b2b86f08ed5d90d5449dfc787e4a1374f2d09b97886e71e7cdbe3cfc25L208-R212)

**Testing Improvements:**

* Added a test to verify that the imperative handle can control split-screen mode externally when enabled. [[1]](diffhunk://#diff-05e7ddcd598d13d09bf37fa44073ac11eacea940c57e5e7ea8d483be314c4923R108) [[2]](diffhunk://#diff-05e7ddcd598d13d09bf37fa44073ac11eacea940c57e5e7ea8d483be314c4923R1170-R1205)

**Versioning:**

* Bumped `@ably/react-web-cli` package version to 0.8.0 to reflect the new API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added external handle for imperative split-screen control (enable/disable/toggle, set position, read state).
  - Introduced option to show or hide the built-in split control; example app includes a Toggle Split button.
  - Component now supports refs for easier programmatic control.

- Tests
  - Added coverage for external split-screen control via the new handle.

- Chores
  - Version bumped to 0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->