### PR TITLE
fix: always install packages on web-cli release

### DIFF
--- a/.github/workflows/release-web-cli.yml
+++ b/.github/workflows/release-web-cli.yml
@@ -48,14 +48,19 @@ jobs:
             echo "should-publish=true" >> $GITHUB_OUTPUT
           fi
 
-      # Only publish if the version doesn't already exist on npm.
-      - name: Install dependencies and publish
-        if: steps.version-check.outputs.should-publish == 'true'
+      - name: Install dependencies
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd packages/react-web-cli
           pnpm install --frozen-lockfile
+
+      - name: Publish
+        if: steps.version-check.outputs.should-publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd packages/react-web-cli
           pnpm run build
           pnpm publish --provenance --access public --no-git-checks
 


### PR DESCRIPTION
Split the dependency install and publish steps so we don't break during the node setup action teardown.

Otherwise the node setup action fails as it doesn't have anything to cache. Not ideal - but it's a known quirk with setup-node.

See: https://github.com/ably/ably-cli/actions/runs/17236706351/job/48903169490