### PR TITLE
Support using the Web CLI in staging

### DIFF
--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -874,22 +874,17 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
     }
 
     // Handle host and environment options
-    if (flags.endpoint) {
-      // The endpoint flag is used to override both realtime and rest hosts
-      // Since Ably SDK ClientOptions doesn't have an endpoint property,
-      // we set it as both realtimeHost and restHost
-      options.realtimeHost = flags.endpoint;
-      options.restHost = flags.endpoint;
-    }
-
     if (flags.host) {
-      // Host flag takes precedence over endpoint
       options.realtimeHost = flags.host;
       options.restHost = flags.host;
     }
 
     if (flags.env) {
       options.environment = flags.env;
+    }
+
+    if (flags.endpoint) {
+      options.endpoint = flags.endpoint
     }
 
     if (flags.port) {

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -107,6 +107,7 @@ export abstract class AblyBaseCommand extends InteractiveBaseCommand {
       description:
         "Override the host endpoint for the control API, which defaults to control.ably.net",
       hidden: process.env.ABLY_SHOW_DEV_FLAGS !== 'true',
+      env: "ABLY_CONTROL_HOST",
     }),
     env: Flags.string({
       description: "Override the environment for all product API calls",

--- a/test/unit/base/base-command.test.ts
+++ b/test/unit/base/base-command.test.ts
@@ -497,8 +497,7 @@ describe("AblyBaseCommand", function() {
 
       const clientOptions = command.testGetClientOptions(flags);
 
-      expect(clientOptions.realtimeHost).to.equal("custom-endpoint.example.com");
-      expect(clientOptions.restHost).to.equal("custom-endpoint.example.com");
+      expect(clientOptions.endpoint).to.equal("custom-endpoint.example.com");
     });
 
     it("should not set endpoint when flag is not provided", function() {
@@ -508,8 +507,7 @@ describe("AblyBaseCommand", function() {
 
       const clientOptions = command.testGetClientOptions(flags);
 
-      expect(clientOptions.realtimeHost).to.be.undefined;
-      expect(clientOptions.restHost).to.be.undefined;
+      expect(clientOptions.endpoint).to.be.undefined;
     });
 
     it("should work alongside other flags like env and host", function() {
@@ -522,7 +520,7 @@ describe("AblyBaseCommand", function() {
 
       const clientOptions = command.testGetClientOptions(flags);
 
-      // When both endpoint and host are provided, host takes precedence
+      expect(clientOptions.endpoint).to.equal("custom-endpoint.example.com");
       expect(clientOptions.environment).to.equal("sandbox");
       expect(clientOptions.realtimeHost).to.equal("custom-host.example.com");
       expect(clientOptions.restHost).to.equal("custom-host.example.com");


### PR DESCRIPTION
This adds `ablyEndpoint` and `ablyControlHost` props to the `AblyCliTerminal` react component which set the `ABLY_ENDPOINT` and `ABLY_CONTROL_HOST` environment variables on the started CLI container respectively, as well as updating the CLI to correctly handle those environment variables (endpoint was accidentally broken in 0b32572).

This allows us to use the Web CLI in staging by setting `ablyEndpoint=nonprod:sandbox` and `ablyControlHost=staging-control.ably-dev.net`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added optional props to configure the Ably endpoint and Control API host in the terminal component.
  * CLI now supports configuring the Control API host via the ABLY_CONTROL_HOST environment variable.
  * Updated endpoint handling: the endpoint flag now maps directly to an endpoint option, while the host flag continues to set host values, preserving precedence.

* Tests
  * Updated unit tests to reflect the new endpoint option behavior and coexistence with host settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->