### PR TITLE
Remove use of `roomId` in Chat commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,25 +176,25 @@ See [MCP Server section](#mcp-server) for more details on how to use the MCP Ser
 * [`ably rooms`](#ably-rooms)
 * [`ably rooms list`](#ably-rooms-list)
 * [`ably rooms messages`](#ably-rooms-messages)
-* [`ably rooms messages history ROOMID`](#ably-rooms-messages-history-roomid)
+* [`ably rooms messages history ROOM`](#ably-rooms-messages-history-room)
 * [`ably rooms messages reactions`](#ably-rooms-messages-reactions)
-* [`ably rooms messages reactions remove ROOMID MESSAGESERIAL REACTION`](#ably-rooms-messages-reactions-remove-roomid-messageserial-reaction)
-* [`ably rooms messages reactions send ROOMID MESSAGESERIAL REACTION`](#ably-rooms-messages-reactions-send-roomid-messageserial-reaction)
-* [`ably rooms messages reactions subscribe ROOMID`](#ably-rooms-messages-reactions-subscribe-roomid)
-* [`ably rooms messages send ROOMID TEXT`](#ably-rooms-messages-send-roomid-text)
-* [`ably rooms messages subscribe ROOMID`](#ably-rooms-messages-subscribe-roomid)
+* [`ably rooms messages reactions remove ROOM MESSAGESERIAL REACTION`](#ably-rooms-messages-reactions-remove-room-messageserial-reaction)
+* [`ably rooms messages reactions send ROOM MESSAGESERIAL REACTION`](#ably-rooms-messages-reactions-send-room-messageserial-reaction)
+* [`ably rooms messages reactions subscribe ROOM`](#ably-rooms-messages-reactions-subscribe-room)
+* [`ably rooms messages send ROOM TEXT`](#ably-rooms-messages-send-room-text)
+* [`ably rooms messages subscribe ROOM`](#ably-rooms-messages-subscribe-room)
 * [`ably rooms occupancy`](#ably-rooms-occupancy)
-* [`ably rooms occupancy get ROOMID`](#ably-rooms-occupancy-get-roomid)
-* [`ably rooms occupancy subscribe ROOMID`](#ably-rooms-occupancy-subscribe-roomid)
+* [`ably rooms occupancy get ROOM`](#ably-rooms-occupancy-get-room)
+* [`ably rooms occupancy subscribe ROOM`](#ably-rooms-occupancy-subscribe-room)
 * [`ably rooms presence`](#ably-rooms-presence)
-* [`ably rooms presence enter ROOMID`](#ably-rooms-presence-enter-roomid)
-* [`ably rooms presence subscribe ROOMID`](#ably-rooms-presence-subscribe-roomid)
+* [`ably rooms presence enter ROOM`](#ably-rooms-presence-enter-room)
+* [`ably rooms presence subscribe ROOM`](#ably-rooms-presence-subscribe-room)
 * [`ably rooms reactions`](#ably-rooms-reactions)
-* [`ably rooms reactions send ROOMID EMOJI`](#ably-rooms-reactions-send-roomid-emoji)
-* [`ably rooms reactions subscribe ROOMID`](#ably-rooms-reactions-subscribe-roomid)
+* [`ably rooms reactions send ROOM EMOJI`](#ably-rooms-reactions-send-room-emoji)
+* [`ably rooms reactions subscribe ROOM`](#ably-rooms-reactions-subscribe-room)
 * [`ably rooms typing`](#ably-rooms-typing)
-* [`ably rooms typing keystroke ROOMID`](#ably-rooms-typing-keystroke-roomid)
-* [`ably rooms typing subscribe ROOMID`](#ably-rooms-typing-subscribe-roomid)
+* [`ably rooms typing keystroke ROOM`](#ably-rooms-typing-keystroke-room)
+* [`ably rooms typing subscribe ROOM`](#ably-rooms-typing-subscribe-room)
 * [`ably spaces`](#ably-spaces)
 * [`ably spaces cursors`](#ably-spaces-cursors)
 * [`ably spaces cursors get-all SPACEID`](#ably-spaces-cursors-get-all-spaceid)
@@ -3553,17 +3553,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/messages/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/index.ts)_
 
-## `ably rooms messages history ROOMID`
+## `ably rooms messages history ROOM`
 
 Get historical messages from an Ably Chat room
 
 ```
 USAGE
-  $ ably rooms messages history ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms messages history ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-l <value>] [--show-metadata]
 
 ARGUMENTS
-  ROOMID  The room ID to get message history from
+  ROOM  The room to get message history from
 
 FLAGS
   -l, --limit=<value>         [default: 20] Maximum number of messages to retrieve
@@ -3620,18 +3620,18 @@ EXAMPLES
 
 _See code: [src/commands/rooms/messages/reactions/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/reactions/index.ts)_
 
-## `ably rooms messages reactions remove ROOMID MESSAGESERIAL REACTION`
+## `ably rooms messages reactions remove ROOM MESSAGESERIAL REACTION`
 
 Remove a reaction from a message in a chat room
 
 ```
 USAGE
-  $ ably rooms messages reactions remove ROOMID MESSAGESERIAL REACTION [--access-token <value>] [--api-key <value>] [--client-id
+  $ ably rooms messages reactions remove ROOM MESSAGESERIAL REACTION [--access-token <value>] [--api-key <value>] [--client-id
     <value>] [--env <value>] [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
     [--type unique|distinct|multiple]
 
 ARGUMENTS
-  ROOMID         The room ID where the message is located
+  ROOM         The room where the message is located
   MESSAGESERIAL  The serial ID of the message to remove reaction from
   REACTION       The reaction to remove (e.g. 👍, ❤️, 😂)
 
@@ -3665,18 +3665,18 @@ EXAMPLES
 
 _See code: [src/commands/rooms/messages/reactions/remove.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/reactions/remove.ts)_
 
-## `ably rooms messages reactions send ROOMID MESSAGESERIAL REACTION`
+## `ably rooms messages reactions send ROOM MESSAGESERIAL REACTION`
 
 Send a reaction to a message in a chat room
 
 ```
 USAGE
-  $ ably rooms messages reactions send ROOMID MESSAGESERIAL REACTION [--access-token <value>] [--api-key <value>] [--client-id
+  $ ably rooms messages reactions send ROOM MESSAGESERIAL REACTION [--access-token <value>] [--api-key <value>] [--client-id
     <value>] [--env <value>] [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
     [--count <value> --type unique|distinct|multiple]
 
 ARGUMENTS
-  ROOMID         The room ID where the message is located
+  ROOM         The room where the message is located
   MESSAGESERIAL  The serial ID of the message to react to
   REACTION       The reaction to send (e.g. 👍, ❤️, 😂)
 
@@ -3713,17 +3713,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/messages/reactions/send.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/reactions/send.ts)_
 
-## `ably rooms messages reactions subscribe ROOMID`
+## `ably rooms messages reactions subscribe ROOM`
 
 Subscribe to message reactions in a chat room
 
 ```
 USAGE
-  $ ably rooms messages reactions subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms messages reactions subscribe ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--raw]
 
 ARGUMENTS
-  ROOMID  Room ID to subscribe to message reactions in
+  ROOM  Room to subscribe to message reactions in
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3754,18 +3754,18 @@ EXAMPLES
 
 _See code: [src/commands/rooms/messages/reactions/subscribe.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/reactions/subscribe.ts)_
 
-## `ably rooms messages send ROOMID TEXT`
+## `ably rooms messages send ROOM TEXT`
 
 Send a message to an Ably Chat room
 
 ```
 USAGE
-  $ ably rooms messages send ROOMID TEXT [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+  $ ably rooms messages send ROOM TEXT [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
     <value>] [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-c <value>] [-d
     <value>] [--metadata <value>]
 
 ARGUMENTS
-  ROOMID  The room ID to send the message to
+  ROOM  The room to send the message to
   TEXT    The message text to send
 
 FLAGS
@@ -3805,17 +3805,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/messages/send.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/messages/send.ts)_
 
-## `ably rooms messages subscribe ROOMID`
+## `ably rooms messages subscribe ROOM`
 
 Subscribe to messages in an Ably Chat room
 
 ```
 USAGE
-  $ ably rooms messages subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms messages subscribe ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--show-metadata] [-D <value>]
 
 ARGUMENTS
-  ROOMID  The room ID to subscribe to messages from
+  ROOM  The room to subscribe to messages from
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = run indefinitely)
@@ -3870,17 +3870,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/occupancy/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/occupancy/index.ts)_
 
-## `ably rooms occupancy get ROOMID`
+## `ably rooms occupancy get ROOM`
 
 Get current occupancy metrics for a room
 
 ```
 USAGE
-  $ ably rooms occupancy get ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms occupancy get ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
-  ROOMID  Room ID to get occupancy for
+  ROOM  Room to get occupancy for
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3910,17 +3910,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/occupancy/get.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/occupancy/get.ts)_
 
-## `ably rooms occupancy subscribe ROOMID`
+## `ably rooms occupancy subscribe ROOM`
 
 Subscribe to real-time occupancy metrics for a room
 
 ```
 USAGE
-  $ ably rooms occupancy subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms occupancy subscribe ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
-  ROOMID  Room ID to subscribe to occupancy for
+  ROOM  Room to subscribe to occupancy for
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -3967,18 +3967,18 @@ EXAMPLES
 
 _See code: [src/commands/rooms/presence/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/presence/index.ts)_
 
-## `ably rooms presence enter ROOMID`
+## `ably rooms presence enter ROOM`
 
 Enter presence in a chat room and remain present until terminated
 
 ```
 USAGE
-  $ ably rooms presence enter ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms presence enter ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--show-others] [-D <value>]
     [--data <value>]
 
 ARGUMENTS
-  ROOMID  Room ID to enter presence on
+  ROOM  Room to enter presence on
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = run indefinitely)
@@ -4009,17 +4009,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/presence/enter.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/presence/enter.ts)_
 
-## `ably rooms presence subscribe ROOMID`
+## `ably rooms presence subscribe ROOM`
 
 Subscribe to presence events in a chat room
 
 ```
 USAGE
-  $ ably rooms presence subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms presence subscribe ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-D <value>]
 
 ARGUMENTS
-  ROOMID  Room ID to subscribe to presence for
+  ROOM  Room to subscribe to presence for
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = run indefinitely)
@@ -4067,17 +4067,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/reactions/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/reactions/index.ts)_
 
-## `ably rooms reactions send ROOMID EMOJI`
+## `ably rooms reactions send ROOM EMOJI`
 
 Send a reaction in a chat room
 
 ```
 USAGE
-  $ ably rooms reactions send ROOMID EMOJI [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+  $ ably rooms reactions send ROOM EMOJI [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
     <value>] [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--metadata <value>]
 
 ARGUMENTS
-  ROOMID  The room ID to send the reaction to
+  ROOM  The room to send the reaction to
   EMOJI   The emoji reaction to send (e.g. 👍, ❤️, 😂)
 
 FLAGS
@@ -4109,17 +4109,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/reactions/send.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/reactions/send.ts)_
 
-## `ably rooms reactions subscribe ROOMID`
+## `ably rooms reactions subscribe ROOM`
 
 Subscribe to reactions in a chat room
 
 ```
 USAGE
-  $ ably rooms reactions subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms reactions subscribe ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
-  ROOMID  Room ID to subscribe to reactions in
+  ROOM  Room to subscribe to reactions in
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -4166,17 +4166,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/typing/index.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/typing/index.ts)_
 
-## `ably rooms typing keystroke ROOMID`
+## `ably rooms typing keystroke ROOM`
 
 Send a typing indicator in an Ably Chat room (use --autoType to keep typing automatically until terminated)
 
 ```
 USAGE
-  $ ably rooms typing keystroke ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms typing keystroke ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--autoType]
 
 ARGUMENTS
-  ROOMID  The room ID to start typing in
+  ROOM  The room to start typing in
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -4209,17 +4209,17 @@ EXAMPLES
 
 _See code: [src/commands/rooms/typing/keystroke.ts](https://github.com/ably/ably-cli/blob/v0.13.0/src/commands/rooms/typing/keystroke.ts)_
 
-## `ably rooms typing subscribe ROOMID`
+## `ably rooms typing subscribe ROOM`
 
 Subscribe to typing indicators in an Ably Chat room
 
 ```
 USAGE
-  $ ably rooms typing subscribe ROOMID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably rooms typing subscribe ROOM [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
-  ROOMID  The room ID to subscribe to typing indicators from
+  ROOM  The room to subscribe to typing indicators from
 
 FLAGS
   -v, --verbose               Output verbose logs

--- a/src/commands/rooms/list.ts
+++ b/src/commands/rooms/list.ts
@@ -19,7 +19,7 @@ interface RoomStatus {
 
 interface RoomItem {
   channelId: string;
-  roomName: string;
+  room: string;
   status?: RoomStatus;
   [key: string]: unknown;
 }
@@ -104,7 +104,7 @@ export default class RoomsList extends ChatBaseCommand {
             // Only add if we haven't seen this room before
             if (!chatRooms.has(roomName)) {
               // Store the original channel data but with the simple room name
-              const roomData = { ...channel, channelId: roomName, roomName };
+              const roomData = { ...channel, channelId: roomName, room: roomName };
               chatRooms.set(roomName, roomData);
             }
           }
@@ -132,7 +132,7 @@ export default class RoomsList extends ChatBaseCommand {
         );
 
         for (const room of limitedRooms) {
-          this.log(`${chalk.green(room.roomName)}`);
+          this.log(`${chalk.green(room.room)}`);
 
           // Show occupancy if available
           if (room.status?.occupancy?.metrics) {

--- a/src/commands/rooms/messages/history.ts
+++ b/src/commands/rooms/messages/history.ts
@@ -6,8 +6,8 @@ import { ChatBaseCommand } from "../../../chat-base-command.js";
 
 export default class MessagesHistory extends ChatBaseCommand {
   static override args = {
-    roomId: Args.string({
-      description: "The room ID to get message history from",
+    room: Args.string({
+      description: "The room to get message history from",
       required: true,
     }),
   };
@@ -54,7 +54,7 @@ export default class MessagesHistory extends ChatBaseCommand {
       }
 
       // Get the room
-      const room = await chatClient.rooms.get(args.roomId, {});
+      const room = await chatClient.rooms.get(args.room, {});
 
       // Attach to the room
       await room.attach();
@@ -65,7 +65,7 @@ export default class MessagesHistory extends ChatBaseCommand {
             this.formatJsonOutput(
               {
                 limit: flags.limit,
-                roomId: args.roomId,
+                room: args.room,
                 status: "fetching",
                 success: true,
               },
@@ -74,7 +74,7 @@ export default class MessagesHistory extends ChatBaseCommand {
           );
         } else {
           this.log(
-            `${chalk.green("Fetching")} ${chalk.yellow(flags.limit.toString())} ${chalk.green("most recent messages from room:")} ${chalk.bold(args.roomId)}`,
+            `${chalk.green("Fetching")} ${chalk.yellow(flags.limit.toString())} ${chalk.green("most recent messages from room:")} ${chalk.bold(args.room)}`,
           );
         }
       }
@@ -95,7 +95,7 @@ export default class MessagesHistory extends ChatBaseCommand {
                   ? { metadata: message.metadata }
                   : {}),
               })),
-              roomId: args.roomId,
+              room: args.room,
               success: true,
             },
             flags,
@@ -134,14 +134,14 @@ export default class MessagesHistory extends ChatBaseCommand {
       }
 
       // Release the room
-      await chatClient.rooms.release(args.roomId);
+      await chatClient.rooms.release(args.room);
     } catch (error) {
       if (this.shouldOutputJson(flags)) {
         this.log(
           this.formatJsonOutput(
             {
               error: error instanceof Error ? error.message : String(error),
-              roomId: args.roomId,
+              room: args.room,
               success: false,
             },
             flags,

--- a/src/commands/rooms/messages/reactions/send.ts
+++ b/src/commands/rooms/messages/reactions/send.ts
@@ -20,7 +20,7 @@ const REACTION_TYPE_MAP: Record<string, MessageReactionType> = {
 interface MessageReactionResult {
   [key: string]: unknown;
   success: boolean;
-  roomId: string;
+  room: string;
   messageSerial?: string;
   reaction?: string;
   type?: string;
@@ -30,8 +30,8 @@ interface MessageReactionResult {
 
 export default class MessagesReactionsSend extends ChatBaseCommand {
   static override args = {
-    roomId: Args.string({
-      description: "The room ID where the message is located",
+    room: Args.string({
+      description: "The room where the message is located",
       required: true,
     }),
     messageSerial: Args.string({
@@ -91,7 +91,7 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(MessagesReactionsSend);
-    const { roomId, messageSerial, reaction } = args;
+    const { room, messageSerial, reaction } = args;
 
     try {
       // Validate count for Multiple type
@@ -109,7 +109,7 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
         if (this.shouldOutputJson(flags)) {
           this.log(
             this.formatJsonOutput(
-              { error: errorMsg, roomId, success: false },
+              { error: errorMsg, room, success: false },
               flags,
             ),
           );
@@ -151,14 +151,14 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
         flags,
         "room",
         "gettingRoom",
-        `Getting room handle for ${roomId}`,
+        `Getting room handle for ${room}`,
       );
-      const room = await this.chatClient.rooms.get(roomId);
+      const chatRoom = await this.chatClient.rooms.get(room);
       this.logCliEvent(
         flags,
         "room",
         "gotRoom",
-        `Got room handle for ${roomId}`,
+        `Got room handle for ${room}`,
       );
 
       // Subscribe to room status changes
@@ -168,11 +168,11 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
         "subscribingToStatus",
         "Subscribing to room status changes",
       );
-      const { off: unsubscribeStatus } = room.onStatusChange(
+      const { off: unsubscribeStatus } = chatRoom.onStatusChange(
         (statusChange: RoomStatusChange) => {
           let reason: Error | null | string | undefined;
           if (statusChange.current === RoomStatus.Failed) {
-            reason = room.error; // Get reason from room.error on failure
+            reason = chatRoom.error; // Get reason from chatRoom.error on failure
           }
 
           const reasonMsg = reason instanceof Error ? reason.message : reason;
@@ -207,14 +207,14 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
         flags,
         "room",
         "attaching",
-        `Attaching to room ${roomId}`,
+        `Attaching to room ${room}`,
       );
-      await room.attach();
+      await chatRoom.attach();
       this.logCliEvent(
         flags,
         "room",
         "attached",
-        `Successfully attached to room ${roomId}`,
+        `Successfully attached to room ${room}`,
       );
 
       // Prepare the reaction parameters
@@ -246,7 +246,7 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
         },
       );
 
-      await room.messages.reactions.send(
+      await chatRoom.messages.reactions.send(
         { serial: messageSerial },
         reactionParams,
       );
@@ -262,7 +262,7 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
       const resultData: MessageReactionResult = {
         messageSerial,
         reaction,
-        roomId,
+        room,
         success: true,
         ...(flags.type && { type: flags.type }),
         ...(flags.count && { count: flags.count }),
@@ -272,14 +272,14 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
         this.log(this.formatJsonOutput(resultData, flags));
       } else {
         this.log(
-          `${chalk.green("✓")} Sent reaction ${chalk.yellow(reaction)} to message ${chalk.cyan(messageSerial)} in room ${chalk.cyan(roomId)}`,
+          `${chalk.green("✓")} Sent reaction ${chalk.yellow(reaction)} to message ${chalk.cyan(messageSerial)} in room ${chalk.cyan(room)}`,
         );
       }
 
       // Clean up resources
-      this.logCliEvent(flags, "room", "releasing", `Releasing room ${roomId}`);
-      await this.chatClient.rooms.release(roomId);
-      this.logCliEvent(flags, "room", "released", `Released room ${roomId}`);
+      this.logCliEvent(flags, "room", "releasing", `Releasing room ${room}`);
+      await this.chatClient.rooms.release(room);
+      this.logCliEvent(flags, "room", "released", `Released room ${room}`);
 
       this.logCliEvent(
         flags,
@@ -301,7 +301,7 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
         "reaction",
         "error",
         `Failed to send reaction: ${errorMsg}`,
-        { error: errorMsg, roomId, messageSerial, reaction },
+        { error: errorMsg, room, messageSerial, reaction },
       );
 
       // Close the connection in case of error
@@ -314,7 +314,7 @@ export default class MessagesReactionsSend extends ChatBaseCommand {
           this.formatJsonOutput(
             {
               error: errorMsg,
-              roomId,
+              room,
               messageSerial,
               reaction,
               success: false,

--- a/src/commands/rooms/occupancy/get.ts
+++ b/src/commands/rooms/occupancy/get.ts
@@ -5,8 +5,8 @@ import { ChatBaseCommand } from "../../../chat-base-command.js";
 
 export default class RoomsOccupancyGet extends ChatBaseCommand {
   static args = {
-    roomId: Args.string({
-      description: "Room ID to get occupancy for",
+    room: Args.string({
+      description: "Room to get occupancy for",
       required: true,
     }),
   };
@@ -101,10 +101,10 @@ export default class RoomsOccupancyGet extends ChatBaseCommand {
         return;
       }
 
-      const { roomId } = args;
+      const { room: roomName } = args;
 
       // Get the room with occupancy enabled
-      this.room = await this.chatClient.rooms.get(roomId, {});
+      this.room = await this.chatClient.rooms.get(roomName, {});
 
       // Attach to the room to access occupancy with timeout
       await Promise.race([
@@ -128,14 +128,14 @@ export default class RoomsOccupancyGet extends ChatBaseCommand {
           this.formatJsonOutput(
             {
               metrics: occupancyMetrics,
-              roomId,
+              room: roomName,
               success: true,
             },
             flags,
           ),
         );
       } else {
-        this.log(`Occupancy metrics for room '${roomId}':\n`);
+        this.log(`Occupancy metrics for room '${roomName}':\n`);
         this.log(`Connections: ${occupancyMetrics.connections ?? 0}`);
 
         this.log(`Presence Members: ${occupancyMetrics.presenceMembers ?? 0}`);
@@ -147,7 +147,7 @@ export default class RoomsOccupancyGet extends ChatBaseCommand {
           this.formatJsonOutput(
             {
               error: error instanceof Error ? error.message : String(error),
-              roomId: args.roomId,
+              room: args.room,
               success: false,
             },
             flags,

--- a/src/commands/rooms/reactions/send.ts
+++ b/src/commands/rooms/reactions/send.ts
@@ -7,8 +7,8 @@ import { ChatBaseCommand } from "../../../chat-base-command.js";
 
 export default class RoomsReactionsSend extends ChatBaseCommand {
   static override args = {
-    roomId: Args.string({
-      description: "The room ID to send the reaction to",
+    room: Args.string({
+      description: "The room to send the reaction to",
       required: true,
     }),
     emoji: Args.string({
@@ -61,7 +61,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(RoomsReactionsSend);
-    const { roomId, emoji } = args;
+    const { room: roomName, emoji } = args;
 
     try {
       // Parse metadata if provided
@@ -79,12 +79,12 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
           const errorMsg = `Invalid metadata JSON: ${error instanceof Error ? error.message : String(error)}`;
           this.logCliEvent(flags, "reaction", "metadataParseError", errorMsg, {
             error: errorMsg,
-            roomId,
+            room: roomName,
           });
           if (this.shouldOutputJson(flags)) {
             this.log(
               this.formatJsonOutput(
-                { error: errorMsg, roomId, success: false },
+                { error: errorMsg, room: roomName, success: false },
                 flags,
               ),
             );
@@ -128,14 +128,14 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
         flags,
         "room",
         "gettingRoom",
-        `Getting room handle for ${roomId}`,
+        `Getting room handle for ${roomName}`,
       );
-      const room = await this.chatClient.rooms.get(roomId, {});
+      const room = await this.chatClient.rooms.get(roomName, {});
       this.logCliEvent(
         flags,
         "room",
         "gotRoom",
-        `Got room handle for ${roomId}`,
+        `Got room handle for ${roomName}`,
       );
 
       // Subscribe to room status changes
@@ -184,14 +184,14 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
         flags,
         "room",
         "attaching",
-        `Attaching to room ${roomId}`,
+        `Attaching to room ${roomName}`,
       );
       await room.attach();
       this.logCliEvent(
         flags,
         "room",
         "attached",
-        `Successfully attached to room ${roomId}`,
+        `Successfully attached to room ${roomName}`,
       );
 
       // Send the reaction
@@ -217,7 +217,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
       const resultData = {
         emoji,
         metadata: this.metadataObj,
-        roomId,
+        room: roomName,
         success: true,
       };
 
@@ -225,14 +225,14 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
         this.log(this.formatJsonOutput(resultData, flags));
       } else {
         this.log(
-          `${chalk.green("✓")} Sent reaction ${emoji} in room ${chalk.cyan(roomId)}`,
+          `${chalk.green("✓")} Sent reaction ${emoji} in room ${chalk.cyan(roomName)}`,
         );
       }
 
       // Clean up resources
-      this.logCliEvent(flags, "room", "releasing", `Releasing room ${roomId}`);
-      await this.chatClient.rooms.release(roomId);
-      this.logCliEvent(flags, "room", "released", `Released room ${roomId}`);
+      this.logCliEvent(flags, "room", "releasing", `Releasing room ${roomName}`);
+      await this.chatClient.rooms.release(roomName);
+      this.logCliEvent(flags, "room", "released", `Released room ${roomName}`);
 
       this.logCliEvent(
         flags,
@@ -254,7 +254,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
         "reaction",
         "error",
         `Failed to send reaction: ${errorMsg}`,
-        { error: errorMsg, roomId, emoji },
+        { error: errorMsg, room: roomName, emoji },
       );
 
       // Close the connection in case of error
@@ -265,7 +265,7 @@ export default class RoomsReactionsSend extends ChatBaseCommand {
       if (this.shouldOutputJson(flags)) {
         this.log(
           this.formatJsonOutput(
-            { error: errorMsg, roomId, emoji, success: false },
+            { error: errorMsg, room: roomName, emoji, success: false },
             flags,
           ),
         );

--- a/src/commands/rooms/reactions/subscribe.ts
+++ b/src/commands/rooms/reactions/subscribe.ts
@@ -7,8 +7,8 @@ import { ChatBaseCommand } from "../../../chat-base-command.js";
 
 export default class RoomsReactionsSubscribe extends ChatBaseCommand {
   static override args = {
-    roomId: Args.string({
-      description: "Room ID to subscribe to reactions in",
+    room: Args.string({
+      description: "Room to subscribe to reactions in",
       required: true,
     }),
   };
@@ -73,7 +73,7 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
       }
 
       // const { chatClient, realtimeClient } = this.clients // Remove deconstruction
-      const { roomId } = args;
+      const { room: roomName } = args;
 
       // Set up connection state logging
       this.setupConnectionStateLogging(this.ablyClient, flags, {
@@ -84,11 +84,11 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
         flags,
         "subscribe",
         "connecting",
-        `Connecting to Ably and subscribing to reactions in room ${roomId}...`,
+        `Connecting to Ably and subscribing to reactions in room ${roomName}...`,
       );
       if (!this.shouldOutputJson(flags)) {
         this.log(
-          `Connecting to Ably and subscribing to reactions in room ${chalk.cyan(roomId)}...`,
+          `Connecting to Ably and subscribing to reactions in room ${chalk.cyan(roomName)}...`,
         );
       }
 
@@ -97,14 +97,14 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
         flags,
         "room",
         "gettingRoom",
-        `Getting room handle for ${roomId}`,
+        `Getting room handle for ${roomName}`,
       );
-      const room = await this.chatClient.rooms.get(roomId, {});
+      const room = await this.chatClient.rooms.get(roomName, {});
       this.logCliEvent(
         flags,
         "room",
         "gotRoom",
-        `Got room handle for ${roomId}`,
+        `Got room handle for ${roomName}`,
       );
 
       // Subscribe to room status changes
@@ -134,7 +134,7 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
             if (!this.shouldOutputJson(flags)) {
               this.log(chalk.green("Successfully connected to Ably"));
               this.log(
-                `Listening for reactions in room ${chalk.cyan(roomId)}. Press Ctrl+C to exit.`,
+                `Listening for reactions in room ${chalk.cyan(roomName)}. Press Ctrl+C to exit.`,
               );
             }
 
@@ -174,7 +174,7 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
         flags,
         "room",
         "attaching",
-        `Attaching to room ${roomId}`,
+        `Attaching to room ${roomName}`,
       );
       await room.attach();
       // Successful attach logged by onStatusChange handler
@@ -192,7 +192,7 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
         const eventData = {
           clientId: reaction.clientId,
           metadata: reaction.metadata,
-          roomId,
+          room: roomName,
           timestamp,
           name: reaction.name,
         };
@@ -256,7 +256,7 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
           const forceExitTimeout = setTimeout(() => {
             const errorMsg = "Force exiting after timeout during cleanup";
             this.logCliEvent(flags, "reactions", "forceExit", errorMsg, {
-              roomId,
+              room: roomName,
             });
             if (!this.shouldOutputJson(flags)) {
               this.log(chalk.red("Force exiting after timeout..."));
@@ -326,16 +326,15 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
               flags,
               "room",
               "releasing",
-              `Releasing room ${roomId}`,
+              `Releasing room ${roomName}`,
             );
-            // await chatClient.rooms.release(roomId); // Use this.chatClient
             if (this.chatClient) {
-              await this.chatClient.rooms.release(roomId);
+              await this.chatClient.rooms.release(roomName);
               this.logCliEvent(
                 flags,
                 "room",
                 "released",
-                `Room ${roomId} released`,
+                `Room ${roomName} released`,
               );
             } else {
               this.logCliEvent(
@@ -359,7 +358,7 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
             if (this.shouldOutputJson(flags)) {
               this.log(
                 this.formatJsonOutput(
-                  { error: errorMsg, roomId, success: false },
+                  { error: errorMsg, room: roomName, success: false },
                   flags,
                 ),
               );
@@ -403,12 +402,12 @@ export default class RoomsReactionsSubscribe extends ChatBaseCommand {
       const errorMsg = error instanceof Error ? error.message : String(error);
       this.logCliEvent(flags, "reactions", "fatalError", `Error: ${errorMsg}`, {
         error: errorMsg,
-        roomId: args.roomId,
+        room: args.room,
       });
       if (this.shouldOutputJson(flags)) {
         this.log(
           this.formatJsonOutput(
-            { error: errorMsg, roomId: args.roomId, success: false },
+            { error: errorMsg, room: args.room, success: false },
             flags,
           ),
         );

--- a/src/commands/rooms/typing/subscribe.ts
+++ b/src/commands/rooms/typing/subscribe.ts
@@ -12,8 +12,8 @@ import { ChatBaseCommand } from "../../../chat-base-command.js";
 
 export default class TypingSubscribe extends ChatBaseCommand {
   static override args = {
-    roomId: Args.string({
-      description: "The room ID to subscribe to typing indicators from",
+    room: Args.string({
+      description: "The room to subscribe to typing indicators from",
       required: true,
     }),
   };
@@ -76,7 +76,7 @@ export default class TypingSubscribe extends ChatBaseCommand {
         return;
       }
 
-      const { roomId } = args;
+      const { room: roomName } = args;
 
       // Set up connection state logging
       this.setupConnectionStateLogging(this.ablyClient, flags, {
@@ -88,14 +88,14 @@ export default class TypingSubscribe extends ChatBaseCommand {
         flags,
         "room",
         "gettingRoom",
-        `Getting room handle for ${roomId}`,
+        `Getting room handle for ${roomName}`,
       );
-      const room = await this.chatClient.rooms.get(roomId, {});
+      const room = await this.chatClient.rooms.get(roomName, {});
       this.logCliEvent(
         flags,
         "room",
         "gotRoom",
-        `Got room handle for ${roomId}`,
+        `Got room handle for ${roomName}`,
       );
 
       // Subscribe to room status changes
@@ -124,7 +124,7 @@ export default class TypingSubscribe extends ChatBaseCommand {
           if (statusChange.current === RoomStatus.Attached) {
             if (!this.shouldOutputJson(flags)) {
               this.log(
-                `${chalk.green("Connected to room:")} ${chalk.bold(roomId)}`,
+                `${chalk.green("Connected to room:")} ${chalk.bold(roomName)}`,
               );
               this.log(
                 `${chalk.dim("Listening for typing indicators. Press Ctrl+C to exit.")}`,
@@ -161,7 +161,7 @@ export default class TypingSubscribe extends ChatBaseCommand {
           const currentlyTyping = [...(typingSetEvent.currentlyTyping || [])];
           const eventData = {
             currentlyTyping,
-            roomId,
+            room: roomName,
             timestamp,
           };
           this.logCliEvent(
@@ -218,7 +218,7 @@ export default class TypingSubscribe extends ChatBaseCommand {
         flags,
         "room",
         "attaching",
-        `Attaching to room ${roomId}`,
+        `Attaching to room ${roomName}`,
       );
       await room.attach();
       // Successful attach logged by onStatusChange handler
@@ -308,14 +308,14 @@ export default class TypingSubscribe extends ChatBaseCommand {
               flags,
               "room",
               "releasing",
-              `Releasing room ${roomId}`,
+              `Releasing room ${roomName}`,
             );
-            await this.chatClient?.rooms.release(roomId);
+            await this.chatClient?.rooms.release(roomName);
             this.logCliEvent(
               flags,
               "room",
               "released",
-              `Room ${roomId} released`,
+              `Room ${roomName} released`,
             );
           } catch (error) {
             this.logCliEvent(
@@ -357,7 +357,7 @@ export default class TypingSubscribe extends ChatBaseCommand {
         "typing",
         "fatalError",
         `Failed to subscribe to typing indicators: ${errorMsg}`,
-        { error: errorMsg, roomId: args.roomId },
+        { error: errorMsg, room: args.room },
       );
       // Close the connection in case of error
       if (this.ablyClient) {
@@ -367,7 +367,7 @@ export default class TypingSubscribe extends ChatBaseCommand {
       if (this.shouldOutputJson(flags)) {
         this.log(
           this.formatJsonOutput(
-            { error: errorMsg, roomId: args.roomId, success: false },
+            { error: errorMsg, room: args.room, success: false },
             flags,
           ),
         );

--- a/test/e2e/rooms/rooms-e2e.test.ts
+++ b/test/e2e/rooms/rooms-e2e.test.ts
@@ -67,7 +67,7 @@ describe('Rooms E2E Tests', function() {
     process.removeListener('SIGINT', forceExit);
   });
 
-  let testRoomId: string;
+  let testRoom: string;
   let client1Id: string;
   let client2Id: string;
 
@@ -77,7 +77,7 @@ describe('Rooms E2E Tests', function() {
     testOutputFiles.clear();
     testCommands.length = 0;
     
-    testRoomId = getUniqueChannelName("room");
+    testRoom = getUniqueChannelName("room");
     client1Id = getUniqueClientId("client1");
     client2Id = getUniqueClientId("client2");
   });
@@ -96,7 +96,7 @@ describe('Rooms E2E Tests', function() {
         try {
           // Start client1 entering presence (this is a long-running command)
           presenceRunner = await startPresenceCommand(
-            ['rooms', 'presence', 'enter', testRoomId, '--data', '{"name":"TestUser1"}', '--client-id', client1Id, '--duration', '15'],
+            ['rooms', 'presence', 'enter', testRoom, '--data', '{"name":"TestUser1"}', '--client-id', client1Id, '--duration', '15'],
             /Entered room/,
             { timeoutMs: process.env.CI ? 20000 : 15000 }
           );
@@ -114,7 +114,7 @@ describe('Rooms E2E Tests', function() {
           while (attempts < maxAttempts) {
             attempts++;
             
-            occupancyResult = await runCommand(['rooms', 'occupancy', 'get', testRoomId], {
+            occupancyResult = await runCommand(['rooms', 'occupancy', 'get', testRoom], {
               timeoutMs: process.env.CI ? 15000 : 10000
             });
 
@@ -155,7 +155,7 @@ describe('Rooms E2E Tests', function() {
           try {
             // Start client1 subscribing to presence events
             subscribeRunner = await startSubscribeCommand(
-              ['rooms', 'presence', 'subscribe', testRoomId, '--client-id', client1Id, '--duration', '35'],
+              ['rooms', 'presence', 'subscribe', testRoom, '--client-id', client1Id, '--duration', '35'],
               /Subscribing to presence events/,
               { timeoutMs: process.env.CI ? 30000 : 20000 }
             );
@@ -166,7 +166,7 @@ describe('Rooms E2E Tests', function() {
 
             // Have client2 enter the room
             enterRunner = await startPresenceCommand(
-              ['rooms', 'presence', 'enter', testRoomId, '--data', '{"name":"TestUser2","status":"active"}', '--client-id', client2Id, '--duration', '25'],
+              ['rooms', 'presence', 'enter', testRoom, '--data', '{"name":"TestUser2","status":"active"}', '--client-id', client2Id, '--duration', '25'],
               /Entered room/,
               { timeoutMs: process.env.CI ? 30000 : 20000 }
             );
@@ -208,7 +208,7 @@ describe('Rooms E2E Tests', function() {
           try {
             // Start subscribing to messages with client1
             subscribeRunner = await startSubscribeCommand(
-              ['rooms', 'messages', 'subscribe', testRoomId, '--client-id', client1Id, '--duration', '60'],
+              ['rooms', 'messages', 'subscribe', testRoom, '--client-id', client1Id, '--duration', '60'],
               'Connected to room:',
               { timeoutMs: process.env.CI ? 45000 : 25000 }
             );
@@ -219,7 +219,7 @@ describe('Rooms E2E Tests', function() {
 
             // Have client2 send a message
             const testMessage = "Hello from E2E test!";
-            const sendResult = await runCommand(['rooms', 'messages', 'send', testRoomId, testMessage, '--client-id', client2Id], {
+            const sendResult = await runCommand(['rooms', 'messages', 'send', testRoom, testMessage, '--client-id', client2Id], {
               timeoutMs: process.env.CI ? 30000 : 20000
             });
 
@@ -237,7 +237,7 @@ describe('Rooms E2E Tests', function() {
             const secondMessage = "Second test message with metadata";
             const metadata = { timestamp: Date.now(), type: "test" };
             const sendResult2 = await runCommand([
-              'rooms', 'messages', 'send', testRoomId, secondMessage, 
+              'rooms', 'messages', 'send', testRoom, secondMessage, 
               '--metadata', JSON.stringify(metadata), '--client-id', client2Id
             ], {
               timeoutMs: process.env.CI ? 15000 : 10000

--- a/test/integration/commands/rooms.test.ts
+++ b/test/integration/commands/rooms.test.ts
@@ -37,8 +37,8 @@ const mockOccupancy = {
 };
 
 // Create comprehensive mock for Chat client and room
-const createMockRoom = (roomId: string) => ({
-  id: roomId,
+const createMockRoom = (room: string) => ({
+  id: room,
   attach: async () => {},
   detach: async () => {},
   
@@ -170,8 +170,8 @@ const createMockRoom = (roomId: string) => ({
 
 const mockChatClient = {
   rooms: {
-    get: (roomId: string) => createMockRoom(roomId),
-    release: async (roomId: string) => {},
+    get: (room: string) => createMockRoom(room),
+    release: async (room: string) => {},
   },
 };
 
@@ -220,12 +220,12 @@ describe('Rooms integration tests', function() {
   });
 
   describe('Chat room lifecycle', function() {
-    const testRoomId = 'integration-test-room';
+    const testRoom = 'integration-test-room';
     
     it('sends a message to a room', function() {
       return test
         .stdout()
-        .command(['rooms', 'messages', 'send', testRoomId, 'Hello from integration test!'])
+        .command(['rooms', 'messages', 'send', testRoom, 'Hello from integration test!'])
         .it('successfully sends a message', ctx => {
           expect(ctx.stdout).to.contain('Message sent successfully');
         });
@@ -234,7 +234,7 @@ describe('Rooms integration tests', function() {
     it('sends multiple messages with metadata', function() {
       return test
         .stdout()
-        .command(['rooms', 'messages', 'send', testRoomId, 'Message with metadata', '--metadata', '{"priority":"high"}', '--count', '3'])
+        .command(['rooms', 'messages', 'send', testRoom, 'Message with metadata', '--metadata', '{"priority":"high"}', '--count', '3'])
         .it('sends multiple messages with metadata', ctx => {
           expect(ctx.stdout).to.contain('messages sent successfully');
         });
@@ -243,7 +243,7 @@ describe('Rooms integration tests', function() {
     it('retrieves message history', function() {
       return test
         .stdout()
-        .command(['rooms', 'messages', 'get', testRoomId, '--limit', '10'])
+        .command(['rooms', 'messages', 'get', testRoom, '--limit', '10'])
         .it('retrieves room message history', ctx => {
           expect(ctx.stdout).to.contain('Hello room!');
           expect(ctx.stdout).to.contain('How is everyone?');
@@ -253,7 +253,7 @@ describe('Rooms integration tests', function() {
     it('enters room presence with data', function() {
       return test
         .stdout()
-        .command(['rooms', 'presence', 'enter', testRoomId, '--data', '{"name":"Integration Tester","role":"tester"}'])
+        .command(['rooms', 'presence', 'enter', testRoom, '--data', '{"name":"Integration Tester","role":"tester"}'])
         .it('enters presence successfully', ctx => {
           // Since presence enter runs indefinitely, we check initial setup
           expect(ctx.stdout).to.contain('Entered presence');
@@ -263,7 +263,7 @@ describe('Rooms integration tests', function() {
     it('gets room occupancy metrics', function() {
       return test
         .stdout()
-        .command(['rooms', 'occupancy', 'get', testRoomId])
+        .command(['rooms', 'occupancy', 'get', testRoom])
         .it('retrieves occupancy metrics', ctx => {
           expect(ctx.stdout).to.contain('Connections:');
           expect(ctx.stdout).to.contain('Publishers:');
@@ -274,7 +274,7 @@ describe('Rooms integration tests', function() {
     it('sends a reaction to a room', function() {
       return test
         .stdout()
-        .command(['rooms', 'reactions', 'send', testRoomId, '🚀'])
+        .command(['rooms', 'reactions', 'send', testRoom, '🚀'])
         .it('sends reaction successfully', ctx => {
           expect(ctx.stdout).to.contain('Reaction sent successfully');
         });
@@ -283,7 +283,7 @@ describe('Rooms integration tests', function() {
     it('starts typing indicator', function() {
       return test
         .stdout()
-        .command(['rooms', 'typing', 'keystroke', testRoomId])
+        .command(['rooms', 'typing', 'keystroke', testRoom])
         .it('starts typing indicator', ctx => {
           expect(ctx.stdout).to.contain('Typing indicator started');
         });
@@ -291,23 +291,23 @@ describe('Rooms integration tests', function() {
   });
 
   describe('JSON output format', function() {
-    const testRoomId = 'json-test-room';
+    const testRoom = 'json-test-room';
 
     it('outputs message send result in JSON format', function() {
       return test
         .stdout()
-        .command(['rooms', 'messages', 'send', testRoomId, 'JSON test message', '--json'])
+        .command(['rooms', 'messages', 'send', testRoom, 'JSON test message', '--json'])
         .it('outputs JSON result', ctx => {
           const output = JSON.parse(ctx.stdout);
           expect(output).to.have.property('success', true);
-          expect(output).to.have.property('roomId', testRoomId);
+          expect(output).to.have.property('room', testRoom);
         });
     });
 
     it('outputs message history in JSON format', function() {
       return test
         .stdout()
-        .command(['rooms', 'messages', 'get', testRoomId, '--json'])
+        .command(['rooms', 'messages', 'get', testRoom, '--json'])
         .it('outputs JSON history', ctx => {
           const output = JSON.parse(ctx.stdout);
           expect(output).to.have.property('messages').that.is.an('array');
@@ -317,7 +317,7 @@ describe('Rooms integration tests', function() {
     it('outputs occupancy metrics in JSON format', function() {
       return test
         .stdout()
-        .command(['rooms', 'occupancy', 'get', testRoomId, '--json'])
+        .command(['rooms', 'occupancy', 'get', testRoom, '--json'])
         .it('outputs JSON occupancy', ctx => {
           const output = JSON.parse(ctx.stdout);
           expect(output).to.have.property('connections');
@@ -360,13 +360,13 @@ describe('Rooms integration tests', function() {
   });
 
   describe('Real-time message flow simulation', function() {
-    const testRoomId = 'realtime-test-room';
+    const testRoom = 'realtime-test-room';
 
     it('simulates sending and then subscribing to messages', function() {
       // This test simulates a real flow where we send a message and then subscribe
       return test
         .stdout()
-        .command(['rooms', 'messages', 'send', testRoomId, 'Test message for subscription'])
+        .command(['rooms', 'messages', 'send', testRoom, 'Test message for subscription'])
         .it('sends message for subscription test', ctx => {
           expect(ctx.stdout).to.contain('Message sent successfully');
         });
@@ -376,7 +376,7 @@ describe('Rooms integration tests', function() {
       // Test presence enter followed by checking presence
       return test
         .stdout()
-        .command(['rooms', 'presence', 'enter', testRoomId, '--data', '{"status":"testing"}'])
+        .command(['rooms', 'presence', 'enter', testRoom, '--data', '{"status":"testing"}'])
         .it('enters presence for lifecycle test', ctx => {
           expect(ctx.stdout).to.contain('Entered presence');
         });

--- a/test/unit/commands/rooms/features.test.ts
+++ b/test/unit/commands/rooms/features.test.ts
@@ -201,7 +201,7 @@ describe("rooms feature commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { roomId: "test-room" },
+        args: { room: "test-room" },
         argv: [],
         raw: [],
       });
@@ -256,7 +256,7 @@ describe("rooms feature commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { roomId: "test-room" },
+        args: { room: "test-room" },
         argv: [],
         raw: [],
       });
@@ -328,7 +328,7 @@ describe("rooms feature commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { roomId: "test-room" },
+        args: { room: "test-room" },
         argv: [],
         raw: [],
       });
@@ -350,7 +350,7 @@ describe("rooms feature commands", function () {
     it("should handle presence data", async function () {
       command.setParseResult({
         flags: { data: '{"status": "online", "name": "Test User"}' },
-        args: { roomId: "test-room" },
+        args: { room: "test-room" },
         argv: [],
         raw: [],
       });
@@ -404,7 +404,7 @@ describe("rooms feature commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { roomId: "test-room", emoji: "👍" },
+        args: { room: "test-room", emoji: "👍" },
         argv: [],
         raw: [],
       });
@@ -422,7 +422,7 @@ describe("rooms feature commands", function () {
     it("should handle metadata in reactions", async function () {
       command.setParseResult({
         flags: { metadata: '{"intensity": "high"}' },
-        args: { roomId: "test-room", emoji: "🎉" },
+        args: { room: "test-room", emoji: "🎉" },
         argv: [],
         raw: [],
       });
@@ -476,7 +476,7 @@ describe("rooms feature commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { roomId: "test-room" },
+        args: { room: "test-room" },
         argv: [],
         raw: [],
       });

--- a/test/unit/commands/rooms/messages.test.ts
+++ b/test/unit/commands/rooms/messages.test.ts
@@ -160,7 +160,7 @@ describe("rooms messages commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { roomId: "test-room", text: "Hello World" },
+        args: { room: "test-room", text: "Hello World" },
         argv: [],
         raw: [],
       });
@@ -180,7 +180,7 @@ describe("rooms messages commands", function () {
     it("should send multiple messages with interpolation", async function () {
       command.setParseResult({
         flags: { count: 3, delay: 10 },
-        args: { roomId: "test-room", text: "Message {{.Count}}" },
+        args: { room: "test-room", text: "Message {{.Count}}" },
         argv: [],
         raw: [],
       });
@@ -201,7 +201,7 @@ describe("rooms messages commands", function () {
     it("should handle metadata in messages", async function () {
       command.setParseResult({
         flags: { metadata: '{"isImportant": true}' },
-        args: { roomId: "test-room", text: "Important message" },
+        args: { room: "test-room", text: "Important message" },
         argv: [],
         raw: [],
       });
@@ -218,7 +218,7 @@ describe("rooms messages commands", function () {
     it("should handle invalid metadata JSON", async function () {
       command.setParseResult({
         flags: { metadata: "invalid-json" },
-        args: { roomId: "test-room", text: "Test message" },
+        args: { room: "test-room", text: "Test message" },
         argv: [],
         raw: [],
       });
@@ -272,7 +272,7 @@ describe("rooms messages commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { roomId: "test-room" },
+        args: { room: "test-room" },
         argv: [],
         raw: [],
       });
@@ -362,7 +362,7 @@ describe("rooms messages commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { roomId: "test-room" },
+        args: { room: "test-room" },
         argv: [],
         raw: [],
       });
@@ -379,7 +379,7 @@ describe("rooms messages commands", function () {
     it("should handle query options for history", async function () {
       command.setParseResult({
         flags: { limit: 50, direction: "forwards" },
-        args: { roomId: "test-room" },
+        args: { room: "test-room" },
         argv: [],
         raw: [],
       });


### PR DESCRIPTION
This PR replaces all occurrences of `roomId` from Ably Chat commands. 

Anything exposed to end-users should now use `room`, or `ROOM`. Internally, there is also use of `roomName` which is the correct name of the property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed CLI argument from roomId to room across all room-related commands (messages, reactions, presence, occupancy, typing).
  - CLI outputs, logs, and JSON payloads now use room instead of roomId.
  - Room listing now exposes room instead of roomName in displayed data.

- Documentation
  - Updated README to standardize on ROOM in command names, usage examples, and argument descriptions, replacing all ROOMID references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->