### PR TITLE
chat: bump chat-js to 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     }
   },
   "dependencies": {
-    "@ably/chat": "^0.13.0",
+    "@ably/chat": "^0.14.0",
     "@ably/spaces": "^0.4.0",
     "@inquirer/prompts": "^5.1.3",
     "@modelcontextprotocol/sdk": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@ably/chat':
-        specifier: ^0.13.0
-        version: 0.13.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.14.0
+        version: 0.14.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ably/spaces':
         specifier: ^0.4.0
         version: 0.4.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -367,11 +367,11 @@ importers:
 
 packages:
 
-  '@ably/chat@0.13.0':
-    resolution: {integrity: sha512-YbTzSn6H821qP6XkqQZwUe4+3IclHuLn15hXBl+fFnu0bHeh9hT4JQyB7t/nGlv4gvCCQpHIRhkksxqGLWiTBg==}
+  '@ably/chat@0.14.0':
+    resolution: {integrity: sha512-9QsJdHVcyYDP0cTHXh7towHI9tM+SbmEMMVK10+0y1N1epl6FBSEeBDMn1fH5i73nxbKleUxjBltWiXlQz4InA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      ably: ^2.9.0
+      ably: ^2.13.0
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -6415,7 +6415,7 @@ packages:
 
 snapshots:
 
-  '@ably/chat@0.13.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@ably/chat@0.14.0(ably@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       ably: 2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       async-mutex: 0.5.0

--- a/src/commands/rooms/presence/enter.ts
+++ b/src/commands/rooms/presence/enter.ts
@@ -1,4 +1,14 @@
-import { ChatClient, Room, RoomStatus, RoomStatusChange, Subscription as ChatSubscription, StatusSubscription, PresenceEvent, PresenceEventType } from "@ably/chat";
+import {
+  ChatClient,
+  Room,
+  RoomStatus,
+  RoomStatusChange,
+  Subscription as ChatSubscription,
+  StatusSubscription,
+  PresenceEvent,
+  PresenceEventType,
+  PresenceData,
+} from "@ably/chat";
 import { Args, Flags, Interfaces } from "@oclif/core";
 import * as Ably from "ably";
 import chalk from "chalk";
@@ -41,7 +51,7 @@ export default class RoomsPresenceEnter extends ChatBaseCommand {
   private chatClient: ChatClient | null = null;
   private room: Room | null = null;
   private roomName: string | null = null;
-  private data: Record<string, unknown> | null = null;
+  private data: PresenceData | null = null;
 
   private unsubscribeStatusFn: StatusSubscription | null = null;
   private unsubscribePresenceFn: ChatSubscription | null = null;


### PR DESCRIPTION
This change bumps chat-js to version 0.14.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chat SDK dependency to v0.14.0 to align with the latest platform improvements.
* **Refactor**
  * Streamlined presence data handling for room presence entry to use a consistent data structure.  
  * No user-visible behavior changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->