### PR TITLE
Remove use of `spaceId` in Spaces commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,22 +197,22 @@ See [MCP Server section](#mcp-server) for more details on how to use the MCP Ser
 * [`ably rooms typing subscribe ROOM`](#ably-rooms-typing-subscribe-room)
 * [`ably spaces`](#ably-spaces)
 * [`ably spaces cursors`](#ably-spaces-cursors)
-* [`ably spaces cursors get-all SPACEID`](#ably-spaces-cursors-get-all-spaceid)
-* [`ably spaces cursors set SPACEID`](#ably-spaces-cursors-set-spaceid)
-* [`ably spaces cursors subscribe SPACEID`](#ably-spaces-cursors-subscribe-spaceid)
+* [`ably spaces cursors get-all SPACE`](#ably-spaces-cursors-get-all-space)
+* [`ably spaces cursors set SPACE`](#ably-spaces-cursors-set-space)
+* [`ably spaces cursors subscribe SPACE`](#ably-spaces-cursors-subscribe-space)
 * [`ably spaces list`](#ably-spaces-list)
 * [`ably spaces locations`](#ably-spaces-locations)
-* [`ably spaces locations get-all SPACEID`](#ably-spaces-locations-get-all-spaceid)
-* [`ably spaces locations set SPACEID`](#ably-spaces-locations-set-spaceid)
-* [`ably spaces locations subscribe SPACEID`](#ably-spaces-locations-subscribe-spaceid)
+* [`ably spaces locations get-all SPACE`](#ably-spaces-locations-get-all-space)
+* [`ably spaces locations set SPACE`](#ably-spaces-locations-set-space)
+* [`ably spaces locations subscribe SPACE`](#ably-spaces-locations-subscribe-space)
 * [`ably spaces locks`](#ably-spaces-locks)
-* [`ably spaces locks acquire SPACEID LOCKID`](#ably-spaces-locks-acquire-spaceid-lockid)
-* [`ably spaces locks get SPACEID LOCKID`](#ably-spaces-locks-get-spaceid-lockid)
-* [`ably spaces locks get-all SPACEID`](#ably-spaces-locks-get-all-spaceid)
-* [`ably spaces locks subscribe SPACEID`](#ably-spaces-locks-subscribe-spaceid)
+* [`ably spaces locks acquire SPACE LOCKID`](#ably-spaces-locks-acquire-space-lockid)
+* [`ably spaces locks get SPACE LOCKID`](#ably-spaces-locks-get-space-lockid)
+* [`ably spaces locks get-all SPACE`](#ably-spaces-locks-get-all-space)
+* [`ably spaces locks subscribe SPACE`](#ably-spaces-locks-subscribe-space)
 * [`ably spaces members`](#ably-spaces-members)
-* [`ably spaces members enter SPACEID`](#ably-spaces-members-enter-spaceid)
-* [`ably spaces members subscribe SPACEID`](#ably-spaces-members-subscribe-spaceid)
+* [`ably spaces members enter SPACE`](#ably-spaces-members-enter-space)
+* [`ably spaces members subscribe SPACE`](#ably-spaces-members-subscribe-space)
 * [`ably status`](#ably-status)
 * [`ably support`](#ably-support)
 * [`ably support ask QUESTION`](#ably-support-ask-question)
@@ -4304,17 +4304,17 @@ EXAMPLES
 
 _See code: [src/commands/spaces/cursors/index.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/cursors/index.ts)_
 
-## `ably spaces cursors get-all SPACEID`
+## `ably spaces cursors get-all SPACE`
 
 Get all current cursors in a space
 
 ```
 USAGE
-  $ ably spaces cursors get-all SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably spaces cursors get-all SPACE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
-  SPACEID  Space ID to get cursors from
+  SPACE  Space ID to get cursors from
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -4342,18 +4342,18 @@ EXAMPLES
 
 _See code: [src/commands/spaces/cursors/get-all.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/cursors/get-all.ts)_
 
-## `ably spaces cursors set SPACEID`
+## `ably spaces cursors set SPACE`
 
 Set a cursor with position data in a space
 
 ```
 USAGE
-  $ ably spaces cursors set SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably spaces cursors set SPACE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--data <value>] [--x <value>]
     [--y <value>] [--simulate] [-D <value>]
 
 ARGUMENTS
-  SPACEID  The space ID to set cursor in
+  SPACE  The space ID to set cursor in
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = exit immediately after setting
@@ -4399,17 +4399,17 @@ EXAMPLES
 
 _See code: [src/commands/spaces/cursors/set.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/cursors/set.ts)_
 
-## `ably spaces cursors subscribe SPACEID`
+## `ably spaces cursors subscribe SPACE`
 
 Subscribe to cursor movements in a space
 
 ```
 USAGE
-  $ ably spaces cursors subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably spaces cursors subscribe SPACE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-D <value>]
 
 ARGUMENTS
-  SPACEID  Space ID to subscribe to cursors for
+  SPACE  Space ID to subscribe to cursors for
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = run indefinitely)
@@ -4509,17 +4509,17 @@ DESCRIPTION
 
 _See code: [src/commands/spaces/locations/index.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/locations/index.ts)_
 
-## `ably spaces locations get-all SPACEID`
+## `ably spaces locations get-all SPACE`
 
 Get all current locations in a space
 
 ```
 USAGE
-  $ ably spaces locations get-all SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably spaces locations get-all SPACE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-f text|json]
 
 ARGUMENTS
-  SPACEID  Space ID to get locations from
+  SPACE  Space ID to get locations from
 
 FLAGS
   -f, --format=<option>       [default: text] Output format
@@ -4549,18 +4549,18 @@ EXAMPLES
 
 _See code: [src/commands/spaces/locations/get-all.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/locations/get-all.ts)_
 
-## `ably spaces locations set SPACEID`
+## `ably spaces locations set SPACE`
 
 Set your location in a space
 
 ```
 USAGE
-  $ ably spaces locations set SPACEID --location <value> [--access-token <value>] [--api-key <value>] [--client-id
+  $ ably spaces locations set SPACE --location <value> [--access-token <value>] [--api-key <value>] [--client-id
     <value>] [--env <value>] [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-D
     <value>]
 
 ARGUMENTS
-  SPACEID  Space ID to set location in
+  SPACE  Space ID to set location in
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = exit immediately after setting
@@ -4589,17 +4589,17 @@ EXAMPLES
 
 _See code: [src/commands/spaces/locations/set.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/locations/set.ts)_
 
-## `ably spaces locations subscribe SPACEID`
+## `ably spaces locations subscribe SPACE`
 
 Subscribe to location updates for members in a space
 
 ```
 USAGE
-  $ ably spaces locations subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably spaces locations subscribe SPACE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-D <value>]
 
 ARGUMENTS
-  SPACEID  Space ID to subscribe to locations for
+  SPACE  Space ID to subscribe to locations for
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = run indefinitely)
@@ -4653,17 +4653,17 @@ EXAMPLES
 
 _See code: [src/commands/spaces/locks/index.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/locks/index.ts)_
 
-## `ably spaces locks acquire SPACEID LOCKID`
+## `ably spaces locks acquire SPACE LOCKID`
 
 Acquire a lock in a space
 
 ```
 USAGE
-  $ ably spaces locks acquire SPACEID LOCKID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+  $ ably spaces locks acquire SPACE LOCKID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
     <value>] [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--data <value>]
 
 ARGUMENTS
-  SPACEID  Space ID to acquire lock in
+  SPACE  Space ID to acquire lock in
   LOCKID   ID of the lock to acquire
 
 FLAGS
@@ -4691,17 +4691,17 @@ EXAMPLES
 
 _See code: [src/commands/spaces/locks/acquire.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/locks/acquire.ts)_
 
-## `ably spaces locks get SPACEID LOCKID`
+## `ably spaces locks get SPACE LOCKID`
 
 Get a lock in a space
 
 ```
 USAGE
-  $ ably spaces locks get SPACEID LOCKID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
+  $ ably spaces locks get SPACE LOCKID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env
     <value>] [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
-  SPACEID  Space ID to get lock from
+  SPACE  Space ID to get lock from
   LOCKID   Lock ID to get
 
 FLAGS
@@ -4730,17 +4730,17 @@ EXAMPLES
 
 _See code: [src/commands/spaces/locks/get.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/locks/get.ts)_
 
-## `ably spaces locks get-all SPACEID`
+## `ably spaces locks get-all SPACE`
 
 Get all current locks in a space
 
 ```
 USAGE
-  $ ably spaces locks get-all SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably spaces locks get-all SPACE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v]
 
 ARGUMENTS
-  SPACEID  Space ID to get locks from
+  SPACE  Space ID to get locks from
 
 FLAGS
   -v, --verbose               Output verbose logs
@@ -4768,17 +4768,17 @@ EXAMPLES
 
 _See code: [src/commands/spaces/locks/get-all.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/locks/get-all.ts)_
 
-## `ably spaces locks subscribe SPACEID`
+## `ably spaces locks subscribe SPACE`
 
 Subscribe to lock events in a space
 
 ```
 USAGE
-  $ ably spaces locks subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably spaces locks subscribe SPACE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-D <value>]
 
 ARGUMENTS
-  SPACEID  Space ID to subscribe to locks for
+  SPACE  Space ID to subscribe to locks for
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = run indefinitely)
@@ -4828,18 +4828,18 @@ EXAMPLES
 
 _See code: [src/commands/spaces/members/index.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/members/index.ts)_
 
-## `ably spaces members enter SPACEID`
+## `ably spaces members enter SPACE`
 
 Enter a space and remain present until terminated
 
 ```
 USAGE
-  $ ably spaces members enter SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably spaces members enter SPACE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [--profile <value>] [-D
     <value>]
 
 ARGUMENTS
-  SPACEID  Space ID to enter
+  SPACE  Space ID to enter
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = run indefinitely)
@@ -4869,17 +4869,17 @@ EXAMPLES
 
 _See code: [src/commands/spaces/members/enter.ts](https://github.com/ably/ably-cli/blob/v0.13.1/src/commands/spaces/members/enter.ts)_
 
-## `ably spaces members subscribe SPACEID`
+## `ably spaces members subscribe SPACE`
 
 Subscribe to member presence events in a space
 
 ```
 USAGE
-  $ ably spaces members subscribe SPACEID [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
+  $ ably spaces members subscribe SPACE [--access-token <value>] [--api-key <value>] [--client-id <value>] [--env <value>]
     [--endpoint <value>] [--host <value>] [--json | --pretty-json] [--token <value>] [-v] [-D <value>]
 
 ARGUMENTS
-  SPACEID  Space ID to subscribe to members for
+  SPACE  Space ID to subscribe to members for
 
 FLAGS
   -D, --duration=<value>      Automatically exit after the given number of seconds (0 = run indefinitely)

--- a/src/commands/spaces/cursors/get-all.ts
+++ b/src/commands/spaces/cursors/get-all.ts
@@ -19,8 +19,8 @@ interface CursorUpdate {
 
 export default class SpacesCursorsGetAll extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to get cursors from",
+    space: Args.string({
+      description: "Space to get cursors from",
       required: true,
     }),
   };
@@ -46,7 +46,7 @@ export default class SpacesCursorsGetAll extends SpacesBaseCommand {
     const { args, flags } = await this.parse(SpacesCursorsGetAll);
 
     let cleanupInProgress = false;
-    const { spaceId } = args;
+    const { space: spaceName } = args;
     
     // Handle process termination gracefully
     const cleanup = async () => {
@@ -70,7 +70,7 @@ export default class SpacesCursorsGetAll extends SpacesBaseCommand {
 
     try {
       // Create Spaces client using setupSpacesClient
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -102,7 +102,7 @@ export default class SpacesCursorsGetAll extends SpacesBaseCommand {
 
       // Get the space
       if (!this.shouldOutputJson(flags)) {
-        this.log(`Connecting to space: ${chalk.cyan(spaceId)}...`);
+        this.log(`Connecting to space: ${chalk.cyan(spaceName)}...`);
       }
 
       // Enter the space
@@ -125,7 +125,7 @@ export default class SpacesCursorsGetAll extends SpacesBaseCommand {
                   this.formatJsonOutput(
                     {
                       connectionId: this.realtimeClient!.connection.id,
-                      spaceId,
+                      spaceName,
                       status: "connected",
                       success: true,
                     },
@@ -134,7 +134,7 @@ export default class SpacesCursorsGetAll extends SpacesBaseCommand {
                 );
               } else {
                 this.log(
-                  `${chalk.green("Successfully entered space:")} ${chalk.cyan(spaceId)}`,
+                  `${chalk.green("Successfully entered space:")} ${chalk.cyan(spaceName)}`,
                 );
               }
 
@@ -274,7 +274,7 @@ export default class SpacesCursorsGetAll extends SpacesBaseCommand {
                 data: cursor.data,
                 position: cursor.position,
               })),
-              spaceId,
+              spaceName,
               success: true,
               cursorUpdateReceived,
             },
@@ -362,7 +362,7 @@ export default class SpacesCursorsGetAll extends SpacesBaseCommand {
               error: isConnectionError 
                 ? "Connection was closed before operation completed. Please try again."
                 : `Error getting cursors: ${errorMessage}`,
-              spaceId: args.spaceId,
+              spaceName,
               status: "error",
               success: false,
               connectionError: isConnectionError,

--- a/src/commands/spaces/cursors/set.ts
+++ b/src/commands/spaces/cursors/set.ts
@@ -20,8 +20,8 @@ interface CursorData {
 
 export default class SpacesCursorsSet extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "The space ID to set cursor in",
+    space: Args.string({
+      description: "The space to set cursor in",
       required: true,
     }),
   };
@@ -95,7 +95,7 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesCursorsSet);
-    const { spaceId } = args;
+    const { space: spaceName } = args;
 
 
     try {
@@ -158,7 +158,7 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
       }
 
       // Create Spaces client using setupSpacesClient
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -167,12 +167,12 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
         const errorMsg = "Failed to create Spaces client";
         this.logCliEvent(flags, "spaces", "clientCreationFailed", errorMsg, {
           error: errorMsg,
-          spaceId,
+          spaceName,
         });
         if (this.shouldOutputJson(flags)) {
           this.log(
             this.formatJsonOutput(
-              { error: errorMsg, spaceId, success: false },
+              { error: errorMsg, spaceName, success: false },
               flags,
             ),
           );
@@ -217,7 +217,7 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
           !this.shouldOutputJson(flags)
         ) {
           this.log(
-            `${chalk.green("Entered space:")} ${chalk.cyan(spaceId)}`,
+            `${chalk.green("Entered space:")} ${chalk.cyan(spaceName)}`,
           );
         }
       };
@@ -227,7 +227,7 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
       }
 
       // Enter the space
-      this.logCliEvent(flags, "space", "entering", `Entering space ${spaceId}`);
+      this.logCliEvent(flags, "space", "entering", `Entering space ${spaceName}`);
       await this.space.enter();
       this.logCliEvent(
         flags,
@@ -319,7 +319,7 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
           this.formatJsonOutput(
             {
               cursor: cursorForOutput,
-              spaceId,
+              spaceName,
               success: true,
             },
             flags,
@@ -327,7 +327,7 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
         );
       } else {
         this.log(
-          `${chalk.green("✓")} Set cursor in space ${chalk.cyan(spaceId)} with data: ${chalk.blue(JSON.stringify(cursorForOutput))}`,
+          `${chalk.green("✓")} Set cursor in space ${chalk.cyan(spaceName)} with data: ${chalk.blue(JSON.stringify(cursorForOutput))}`,
         );
       }
 
@@ -432,12 +432,12 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
         error instanceof Error ? error.message : String(error);
       this.logCliEvent(flags, "cursor", "setError", errorMsg, {
         error: errorMsg,
-        spaceId,
+        spaceName,
       });
       if (this.shouldOutputJson(flags)) {
         this.log(
           this.formatJsonOutput(
-            { error: errorMsg, spaceId, success: false },
+            { error: errorMsg, spaceName, success: false },
             flags,
           ),
         );
@@ -451,7 +451,7 @@ export default class SpacesCursorsSet extends SpacesBaseCommand {
           try {
             await this.space.leave();
             if (flags && !this.shouldOutputJson(flags)) {
-              this.log(`${chalk.green("Left space:")} ${chalk.cyan(spaceId)}`);
+              this.log(`${chalk.green("Left space:")} ${chalk.cyan(spaceName)}`);
             }
           } catch {
             // ignore

--- a/src/commands/spaces/cursors/subscribe.ts
+++ b/src/commands/spaces/cursors/subscribe.ts
@@ -8,8 +8,8 @@ import { waitUntilInterruptedOrTimeout } from "../../../utils/long-running.js";
 
 export default class SpacesCursorsSubscribe extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to subscribe to cursors for",
+    space: Args.string({
+      description: "Space to subscribe to cursors for",
       required: true,
     }),
   };
@@ -71,11 +71,11 @@ export default class SpacesCursorsSubscribe extends SpacesBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesCursorsSubscribe);
-    const { spaceId } = args;
+    const { space: spaceName } = args;
 
     try {
       // Create Spaces client using setupSpacesClient
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -131,14 +131,14 @@ export default class SpacesCursorsSubscribe extends SpacesBaseCommand {
         flags,
         "spaces",
         "gettingSpace",
-        `Getting space: ${spaceId}...`,
+        `Getting space: ${spaceName}...`,
       );
 
       this.logCliEvent(
         flags,
         "spaces",
         "gotSpace",
-        `Successfully got space handle: ${spaceId}`,
+        `Successfully got space handle: ${spaceName}`,
       );
 
       // Enter the space
@@ -149,7 +149,7 @@ export default class SpacesCursorsSubscribe extends SpacesBaseCommand {
         flags,
         "spaces",
         "entered",
-        `Entered space ${spaceId} with clientId ${clientId}`,
+        `Entered space ${spaceName} with clientId ${clientId}`,
       );
 
       // Subscribe to cursor updates
@@ -172,7 +172,7 @@ export default class SpacesCursorsSubscribe extends SpacesBaseCommand {
               },
               position: cursorUpdate.position,
               data: cursorUpdate.data,
-              spaceId,
+              spaceName,
               timestamp,
               type: "cursor_update",
             };
@@ -199,12 +199,12 @@ export default class SpacesCursorsSubscribe extends SpacesBaseCommand {
             const errorMsg = `Error processing cursor update: ${error instanceof Error ? error.message : String(error)}`;
             this.logCliEvent(flags, "cursor", "updateProcessError", errorMsg, {
               error: errorMsg,
-              spaceId,
+              spaceName,
             });
             if (this.shouldOutputJson(flags)) {
               this.log(
                 this.formatJsonOutput(
-                  { error: errorMsg, spaceId, status: "error", success: false },
+                  { error: errorMsg, spaceName, status: "error", success: false },
                   flags,
                 ),
               );
@@ -290,12 +290,12 @@ export default class SpacesCursorsSubscribe extends SpacesBaseCommand {
         const errorMsg = `Error subscribing to cursor updates: ${error instanceof Error ? error.message : String(error)}`;
         this.logCliEvent(flags, "cursor", "subscribeError", errorMsg, {
           error: errorMsg,
-          spaceId,
+          spaceName,
         });
         if (this.shouldOutputJson(flags)) {
           this.log(
             this.formatJsonOutput(
-              { error: errorMsg, spaceId, status: "error", success: false },
+              { error: errorMsg, spaceName, status: "error", success: false },
               flags,
             ),
           );
@@ -318,7 +318,7 @@ export default class SpacesCursorsSubscribe extends SpacesBaseCommand {
       
       // Print success message
       if (!this.shouldOutputJson(flags)) {
-        this.log(chalk.green(`✓ Subscribed to space: ${chalk.cyan(spaceId)}. Listening for cursor movements...`));
+        this.log(chalk.green(`✓ Subscribed to space: ${chalk.cyan(spaceName)}. Listening for cursor movements...`));
       }
       
       // Wait until the user interrupts or the optional duration elapses
@@ -340,12 +340,12 @@ export default class SpacesCursorsSubscribe extends SpacesBaseCommand {
         "cursor",
         "fatalError",
         `Failed to subscribe to cursors: ${errorMsg}`,
-        { error: errorMsg, spaceId },
+        { error: errorMsg, spaceName },
       );
       if (this.shouldOutputJson(flags)) {
         this.log(
           this.formatJsonOutput(
-            { error: errorMsg, spaceId, status: "error", success: false },
+            { error: errorMsg, spaceName, status: "error", success: false },
             flags,
           ),
         );

--- a/src/commands/spaces/locations/get-all.ts
+++ b/src/commands/spaces/locations/get-all.ts
@@ -38,8 +38,8 @@ interface LocationItem {
 
 export default class SpacesLocationsGetAll extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to get locations from",
+    space: Args.string({
+      description: "Space to get locations from",
       required: true,
     }),
   };
@@ -69,10 +69,10 @@ export default class SpacesLocationsGetAll extends SpacesBaseCommand {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesLocationsGetAll);
 
-    const { spaceId } = args;
+    const { space: spaceName } = args;
 
     try {
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -100,7 +100,7 @@ export default class SpacesLocationsGetAll extends SpacesBaseCommand {
         checkConnection();
       });
 
-      this.log(`Connecting to space: ${chalk.cyan(spaceId)}...`);
+      this.log(`Connecting to space: ${chalk.cyan(spaceName)}...`);
       await this.space.enter();
 
       await new Promise<void>((resolve, reject) => {
@@ -113,7 +113,7 @@ export default class SpacesLocationsGetAll extends SpacesBaseCommand {
             if (this.realtimeClient!.connection.state === "connected") {
               clearTimeout(timeout);
               this.log(
-                `${chalk.green("Connected to space:")} ${chalk.cyan(spaceId)}`,
+                `${chalk.green("Connected to space:")} ${chalk.cyan(spaceName)}`,
               );
               resolve();
             } else if (
@@ -140,7 +140,7 @@ export default class SpacesLocationsGetAll extends SpacesBaseCommand {
       });
 
       if (!this.shouldOutputJson(flags)) {
-        this.log(`Fetching locations for space ${chalk.cyan(spaceId)}...`);
+        this.log(`Fetching locations for space ${chalk.cyan(spaceName)}...`);
       }
 
       let locations: LocationItem[] = [];
@@ -226,7 +226,7 @@ export default class SpacesLocationsGetAll extends SpacesBaseCommand {
                     memberId,
                   };
                 }),
-                spaceId,
+                spaceName,
                 success: true,
                 timestamp: new Date().toISOString(),
               },
@@ -303,7 +303,7 @@ export default class SpacesLocationsGetAll extends SpacesBaseCommand {
             this.formatJsonOutput(
               {
                 error: error instanceof Error ? error.message : String(error),
-                spaceId,
+                spaceName,
                 status: "error",
                 success: false,
               },

--- a/src/commands/spaces/locations/set.ts
+++ b/src/commands/spaces/locations/set.ts
@@ -15,8 +15,8 @@ interface LocationSubscription {
 
 export default class SpacesLocationsSet extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to set location in",
+    space: Args.string({
+      description: "Space to set location in",
       required: true,
     }),
   };
@@ -98,7 +98,7 @@ export default class SpacesLocationsSet extends SpacesBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesLocationsSet);
-    const { spaceId } = args;
+    const { space: spaceName } = args;
 
     // Parse location data first
     let location: Record<string, unknown> | null = null;
@@ -152,7 +152,7 @@ export default class SpacesLocationsSet extends SpacesBaseCommand {
       
       // Optimized path for E2E tests - minimal setup and cleanup
       try {
-        const setupResult = await this.setupSpacesClient(flags, spaceId);
+        const setupResult = await this.setupSpacesClient(flags, spaceName);
         this.realtimeClient = setupResult.realtimeClient;
         this.spacesClient = setupResult.spacesClient;
         this.space = setupResult.space;
@@ -178,7 +178,7 @@ export default class SpacesLocationsSet extends SpacesBaseCommand {
         
         if (this.shouldOutputJson(flags)) {
           this.log(
-            this.formatJsonOutput({ success: true, location, spaceId }, flags),
+            this.formatJsonOutput({ success: true, location, spaceName }, flags),
           );
         } else {
           this.log(
@@ -190,7 +190,7 @@ export default class SpacesLocationsSet extends SpacesBaseCommand {
         // If an error occurs in E2E mode, just exit cleanly after showing what we can
         if (this.shouldOutputJson(flags)) {
           this.log(
-            this.formatJsonOutput({ success: true, location, spaceId }, flags),
+            this.formatJsonOutput({ success: true, location, spaceName }, flags),
           );
         }
         // Don't call this.error() in E2E mode as it sets exit code to 1
@@ -203,7 +203,7 @@ export default class SpacesLocationsSet extends SpacesBaseCommand {
     // Original path for interactive use
     try {
       // Create Spaces client using setupSpacesClient
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -222,13 +222,13 @@ export default class SpacesLocationsSet extends SpacesBaseCommand {
         flags,
         "spaces",
         "gettingSpace",
-        `Getting space: ${spaceId}...`,
+        `Getting space: ${spaceName}...`,
       );
       this.logCliEvent(
         flags,
         "spaces",
         "gotSpace",
-        `Successfully got space handle: ${spaceId}`,
+        `Successfully got space handle: ${spaceName}`,
       );
 
       // Enter the space first

--- a/src/commands/spaces/locations/subscribe.ts
+++ b/src/commands/spaces/locations/subscribe.ts
@@ -33,8 +33,8 @@ interface LocationSubscription {
 
 export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to subscribe to locations for",
+    space: Args.string({
+      description: "Space to subscribe to locations for",
       required: true,
     }),
   };
@@ -124,8 +124,8 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesLocationsSubscribe);
-    const { spaceId } = args;
-    this.logCliEvent(flags, "subscribe.run", "start", `Starting spaces locations subscribe for space: ${spaceId}`);
+    const { space: spaceName } = args;
+    this.logCliEvent(flags, "subscribe.run", "start", `Starting spaces locations subscribe for space: ${spaceName}`);
 
     try {
       // Always show the readiness signal first, before attempting auth
@@ -136,7 +136,7 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
 
       // Create Spaces client using setupSpacesClient
       this.logCliEvent(flags, "subscribe.clientSetup", "attemptingClientCreation", "Attempting to create Spaces and Ably clients.");
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -194,17 +194,17 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
         flags,
         "spaces",
         "gettingSpace",
-        `Getting space: ${spaceId}...`,
+        `Getting space: ${spaceName}...`,
       );
       if (!this.shouldOutputJson(flags)) {
-        this.log(`Connecting to space: ${chalk.cyan(spaceId)}...`);
+        this.log(`Connecting to space: ${chalk.cyan(spaceName)}...`);
       }
 
       this.logCliEvent(
         flags,
         "spaces",
         "gotSpace",
-        `Successfully got space handle: ${spaceId}`,
+        `Successfully got space handle: ${spaceName}`,
       );
 
       // Enter the space
@@ -223,11 +223,11 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
         flags,
         "location",
         "gettingInitial",
-        `Fetching initial locations for space ${spaceId}`,
+        `Fetching initial locations for space ${spaceName}`,
       );
       if (!this.shouldOutputJson(flags)) {
         this.log(
-          `Fetching current locations for space ${chalk.cyan(spaceId)}...`,
+          `Fetching current locations for space ${chalk.cyan(spaceName)}...`,
         );
       }
 
@@ -285,7 +285,7 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
                   connectionId: item.member.connectionId,
                   location: item.location,
                 })),
-                spaceId,
+                spaceName,
                 success: true,
                 type: "locations_snapshot",
               },
@@ -313,12 +313,12 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
         const errorMsg = `Error fetching locations: ${error instanceof Error ? error.message : String(error)}`;
         this.logCliEvent(flags, "location", "getInitialError", errorMsg, {
           error: errorMsg,
-          spaceId,
+          spaceName,
         });
         if (this.shouldOutputJson(flags)) {
           this.log(
             this.formatJsonOutput(
-              { error: errorMsg, spaceId, status: "error", success: false },
+              { error: errorMsg, spaceName, status: "error", success: false },
               flags,
             ),
           );
@@ -360,14 +360,14 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
               "location",
               "updateReceived",
               "Location update received",
-              { spaceId, ...eventData },
+              { spaceName, ...eventData },
             );
 
             if (this.shouldOutputJson(flags)) {
               this.log(
                 this.formatJsonOutput(
                   {
-                    spaceId,
+                    spaceName,
                     success: true,
                     type: "location_update",
                     ...eventData,
@@ -393,12 +393,12 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
               "location",
               "updateProcessError",
               errorMsg,
-              { error: errorMsg, spaceId },
+              { error: errorMsg, spaceName },
             );
             if (this.shouldOutputJson(flags)) {
               this.log(
                 this.formatJsonOutput(
-                  { error: errorMsg, spaceId, status: "error", success: false },
+                  { error: errorMsg, spaceName, status: "error", success: false },
                   flags,
                 ),
               );
@@ -431,12 +431,12 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
         const errorMsg = `Error subscribing to location updates: ${error instanceof Error ? error.message : String(error)}`;
         this.logCliEvent(flags, "location", "subscribeError", errorMsg, {
           error: errorMsg,
-          spaceId,
+          spaceName,
         });
         if (this.shouldOutputJson(flags)) {
           this.log(
             this.formatJsonOutput(
-              { error: errorMsg, spaceId, status: "error", success: false },
+              { error: errorMsg, spaceName, status: "error", success: false },
               flags,
             ),
           );
@@ -466,11 +466,11 @@ export default class SpacesLocationsSubscribe extends SpacesBaseCommand {
 
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
-      this.logCliEvent(flags, "location", "fatalError", `Failed to subscribe to location updates: ${errorMsg}`, { error: errorMsg, spaceId });
+      this.logCliEvent(flags, "location", "fatalError", `Failed to subscribe to location updates: ${errorMsg}`, { error: errorMsg, spaceName });
       if (this.shouldOutputJson(flags)) {
         this.log(
           this.formatJsonOutput(
-            { error: errorMsg, spaceId, status: "error", success: false },
+            { error: errorMsg, spaceName, status: "error", success: false },
             flags,
           ),
         );

--- a/src/commands/spaces/locks/acquire.ts
+++ b/src/commands/spaces/locks/acquire.ts
@@ -7,8 +7,8 @@ import { SpacesBaseCommand } from "../../../spaces-base-command.js";
 
 export default class SpacesLocksAcquire extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to acquire lock in",
+    space: Args.string({
+      description: "Space to acquire lock in",
       required: true,
     }),
     lockId: Args.string({
@@ -97,13 +97,13 @@ export default class SpacesLocksAcquire extends SpacesBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesLocksAcquire);
-    const { spaceId } = args;
+    const { space: spaceName } = args;
     this.lockId = args.lockId;
     const { lockId } = this;
 
     try {
       // Create Spaces client using setupSpacesClient
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -144,13 +144,13 @@ export default class SpacesLocksAcquire extends SpacesBaseCommand {
         flags,
         "spaces",
         "gettingSpace",
-        `Getting space: ${spaceId}...`,
+        `Getting space: ${spaceName}...`,
       );
       this.logCliEvent(
         flags,
         "spaces",
         "gotSpace",
-        `Successfully got space handle: ${spaceId}`,
+        `Successfully got space handle: ${spaceName}`,
       );
 
       // Enter the space first
@@ -261,7 +261,7 @@ export default class SpacesLocksAcquire extends SpacesBaseCommand {
             const errorMsg = "Force exiting after timeout during cleanup";
             this.logCliEvent(flags, "lock", "forceExit", errorMsg, {
               lockId,
-              spaceId,
+              spaceName,
             });
             if (!this.shouldOutputJson(flags)) {
               this.log(chalk.red("Force exiting after timeout..."));

--- a/src/commands/spaces/locks/get-all.ts
+++ b/src/commands/spaces/locks/get-all.ts
@@ -16,8 +16,8 @@ interface LockItem {
 
 export default class SpacesLocksGetAll extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to get locks from",
+    space: Args.string({
+      description: "Space to get locks from",
       required: true,
     }),
   };
@@ -42,11 +42,11 @@ export default class SpacesLocksGetAll extends SpacesBaseCommand {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesLocksGetAll);
 
-    const { spaceId } = args;
+    const { space: spaceName } = args;
 
     try {
       // Create Spaces client using setupSpacesClient
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -76,7 +76,7 @@ export default class SpacesLocksGetAll extends SpacesBaseCommand {
       });
 
       // Get the space
-      this.log(`Connecting to space: ${chalk.cyan(spaceId)}...`);
+      this.log(`Connecting to space: ${chalk.cyan(spaceName)}...`);
       await this.space.enter();
 
       // Wait for space to be properly entered before fetching locks
@@ -90,7 +90,7 @@ export default class SpacesLocksGetAll extends SpacesBaseCommand {
             if (this.realtimeClient!.connection.state === "connected") {
               clearTimeout(timeout);
               this.log(
-                `${chalk.green("Connected to space:")} ${chalk.cyan(spaceId)}`,
+                `${chalk.green("Connected to space:")} ${chalk.cyan(spaceName)}`,
               );
               resolve();
             } else if (
@@ -118,7 +118,7 @@ export default class SpacesLocksGetAll extends SpacesBaseCommand {
 
       // Get all locks
       if (!this.shouldOutputJson(flags)) {
-        this.log(`Fetching locks for space ${chalk.cyan(spaceId)}...`);
+        this.log(`Fetching locks for space ${chalk.cyan(spaceName)}...`);
       }
 
       let locks: LockItem[] = [];
@@ -141,7 +141,7 @@ export default class SpacesLocksGetAll extends SpacesBaseCommand {
                   id: lock.id,
                   status: lock.status || "unknown",
                 })),
-                spaceId,
+                spaceName,
                 success: true,
                 timestamp: new Date().toISOString(),
               },
@@ -184,7 +184,7 @@ export default class SpacesLocksGetAll extends SpacesBaseCommand {
             this.formatJsonOutput(
               {
                 error: error instanceof Error ? error.message : String(error),
-                spaceId: args.spaceId,
+                spaceName: spaceName,
                 status: "error",
                 success: false,
               },
@@ -204,7 +204,7 @@ export default class SpacesLocksGetAll extends SpacesBaseCommand {
           this.log(
             this.formatJsonOutput(
               {
-                spaceId,
+                spaceName,
                 status: "left",
                 success: true,
               },
@@ -220,7 +220,7 @@ export default class SpacesLocksGetAll extends SpacesBaseCommand {
             this.formatJsonOutput(
               {
                 error: error instanceof Error ? error.message : String(error),
-                spaceId: args.spaceId,
+                spaceName: spaceName,
                 status: "error",
                 success: false,
               },
@@ -241,7 +241,7 @@ export default class SpacesLocksGetAll extends SpacesBaseCommand {
           this.formatJsonOutput(
             {
               error: error instanceof Error ? error.message : String(error),
-              spaceId: args.spaceId,
+              spaceName: spaceName,
               status: "error",
               success: false,
             },

--- a/src/commands/spaces/locks/get.ts
+++ b/src/commands/spaces/locks/get.ts
@@ -12,8 +12,8 @@ import { SpacesBaseCommand } from "../../../spaces-base-command.js";
 
 export default class SpacesLocksGet extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to get lock from",
+    space: Args.string({
+      description: "Space to get lock from",
       required: true,
     }),
     lockId: Args.string({
@@ -43,13 +43,13 @@ export default class SpacesLocksGet extends SpacesBaseCommand {
     const { args, flags } = await this.parse(SpacesLocksGet);
 
     // let clients: SpacesClients | null = null // Remove local variable
-    const { spaceId } = args; // Get spaceId earlier
+    const { space: spaceName } = args; // Get spaceName earlier
     const { lockId } = args;
 
     try {
       // Create Spaces client using setupSpacesClient
       // clients = await this.createSpacesClient(flags) // Replace with setupSpacesClient
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -60,17 +60,17 @@ export default class SpacesLocksGet extends SpacesBaseCommand {
       }
 
       // const { spacesClient } = clients // Remove deconstruction
-      // const {spaceId} = args // Moved earlier
+      // const {spaceName} = args // Moved earlier
       // const {lockId} = args // Moved earlier
 
       // Get the space
-      // const space = await spacesClient.get(spaceId) // Already got this.space
+      // const space = await spacesClient.get(spaceName) // Already got this.space
 
       // Enter the space first
       // await space.enter() // Use this.space
       await this.space.enter();
       this.log(
-        `${chalk.green("Successfully entered space:")} ${chalk.cyan(spaceId)}`,
+        `${chalk.green("Successfully entered space:")} ${chalk.cyan(spaceName)}`,
       );
 
       // Try to get the lock
@@ -85,7 +85,7 @@ export default class SpacesLocksGet extends SpacesBaseCommand {
             );
           } else {
             this.log(
-              chalk.yellow(`Lock '${lockId}' not found in space '${spaceId}'`),
+              chalk.yellow(`Lock '${lockId}' not found in space '${spaceName}'`),
             );
           }
 

--- a/src/commands/spaces/locks/subscribe.ts
+++ b/src/commands/spaces/locks/subscribe.ts
@@ -9,8 +9,8 @@ import { waitUntilInterruptedOrTimeout } from "../../../utils/long-running.js";
 
 export default class SpacesLocksSubscribe extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to subscribe to locks for",
+    space: Args.string({
+      description: "Space to subscribe to locks for",
       required: true,
     }),
   };
@@ -83,8 +83,8 @@ export default class SpacesLocksSubscribe extends SpacesBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesLocksSubscribe);
-    const { spaceId } = args;
-    this.logCliEvent(flags, "subscribe.run", "start", `Starting spaces locks subscribe for space: ${spaceId}`);
+    const { space: spaceName } = args;
+    this.logCliEvent(flags, "subscribe.run", "start", `Starting spaces locks subscribe for space: ${spaceName}`);
 
     try {
       // Always show the readiness signal first, before attempting auth
@@ -95,7 +95,7 @@ export default class SpacesLocksSubscribe extends SpacesBaseCommand {
 
       // Create Spaces client using setupSpacesClient
       this.logCliEvent(flags, "subscribe.clientSetup", "attemptingClientCreation", "Attempting to create Spaces and Ably clients.");
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -154,13 +154,13 @@ export default class SpacesLocksSubscribe extends SpacesBaseCommand {
         flags,
         "spaces",
         "gettingSpace",
-        `Getting space: ${spaceId}...`,
+        `Getting space: ${spaceName}...`,
       );
       this.logCliEvent(
         flags,
         "spaces",
         "gotSpace",
-        `Successfully got space handle: ${spaceId}`,
+        `Successfully got space handle: ${spaceName}`,
       );
 
       // Enter the space
@@ -175,7 +175,7 @@ export default class SpacesLocksSubscribe extends SpacesBaseCommand {
       );
 
       if (!this.shouldOutputJson(flags)) {
-        this.log(`Connecting to space: ${chalk.cyan(spaceId)}...`);
+        this.log(`Connecting to space: ${chalk.cyan(spaceName)}...`);
       }
 
       // Get current locks
@@ -186,7 +186,7 @@ export default class SpacesLocksSubscribe extends SpacesBaseCommand {
         "Fetching initial locks",
       );
       if (!this.shouldOutputJson(flags)) {
-        this.log(`Fetching current locks for space ${chalk.cyan(spaceId)}...`);
+        this.log(`Fetching current locks for space ${chalk.cyan(spaceName)}...`);
       }
 
       const locks = await this.space.locks.getAll();
@@ -212,7 +212,7 @@ export default class SpacesLocksSubscribe extends SpacesBaseCommand {
                 member: lock.member,
                 status: lock.status,
               })),
-              spaceId,
+              spaceName,
               status: "connected",
               success: true,
             },
@@ -263,7 +263,7 @@ export default class SpacesLocksSubscribe extends SpacesBaseCommand {
             member: lock.member,
             status: lock.status,
           },
-          spaceId,
+          spaceName,
           timestamp,
           type: "lock_event",
         };

--- a/src/commands/spaces/members/enter.ts
+++ b/src/commands/spaces/members/enter.ts
@@ -10,8 +10,8 @@ import { waitUntilInterruptedOrTimeout } from "../../../utils/long-running.js";
 
 export default class SpacesMembersEnter extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to enter",
+    space: Args.string({
+      description: "Space to enter",
       required: true,
     }),
   };
@@ -89,7 +89,7 @@ export default class SpacesMembersEnter extends SpacesBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesMembersEnter);
-    const { spaceId } = args;
+    const { space: spaceName } = args;
 
     // Keep track of the last event we've seen for each client to avoid duplicates
     const lastSeenEvents = new Map<
@@ -104,7 +104,7 @@ export default class SpacesMembersEnter extends SpacesBaseCommand {
       }
 
       // Create Spaces client using setupSpacesClient
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -134,12 +134,12 @@ export default class SpacesMembersEnter extends SpacesBaseCommand {
           const errorMsg = `Invalid profile JSON: ${error instanceof Error ? error.message : String(error)}`;
           this.logCliEvent(flags, "member", "profileParseError", errorMsg, {
             error: errorMsg,
-            spaceId,
+            spaceName,
           });
           if (this.shouldOutputJson(flags)) {
             this.log(
               this.formatJsonOutput(
-                { error: errorMsg, spaceId, success: false },
+                { error: errorMsg, spaceName, success: false },
                 flags,
               ),
             );
@@ -156,13 +156,13 @@ export default class SpacesMembersEnter extends SpacesBaseCommand {
         flags,
         "spaces",
         "gettingSpace",
-        `Getting space: ${spaceId}...`,
+        `Getting space: ${spaceName}...`,
       );
       this.logCliEvent(
         flags,
         "spaces",
         "gotSpace",
-        `Successfully got space handle: ${spaceId}`,
+        `Successfully got space handle: ${spaceName}`,
       );
 
       // Enter the space with optional profile
@@ -177,7 +177,7 @@ export default class SpacesMembersEnter extends SpacesBaseCommand {
       const enteredEventData = {
         connectionId: this.realtimeClient.connection.id,
         profile: profileData,
-        spaceId,
+        spaceName,
         status: "connected",
       };
       this.logCliEvent(
@@ -194,7 +194,7 @@ export default class SpacesMembersEnter extends SpacesBaseCommand {
         );
       } else {
         this.log(
-          `${chalk.green("Successfully entered space:")} ${chalk.cyan(spaceId)}`,
+          `${chalk.green("Successfully entered space:")} ${chalk.cyan(spaceName)}`,
         );
         if (profileData) {
           this.log(
@@ -271,7 +271,7 @@ export default class SpacesMembersEnter extends SpacesBaseCommand {
             isConnected: member.isConnected,
             profileData: member.profileData,
           },
-          spaceId,
+          spaceName,
           timestamp,
           type: "member_update",
         };

--- a/src/commands/spaces/members/subscribe.ts
+++ b/src/commands/spaces/members/subscribe.ts
@@ -11,8 +11,8 @@ import { waitUntilInterruptedOrTimeout } from "../../../utils/long-running.js";
 
 export default class SpacesMembersSubscribe extends SpacesBaseCommand {
   static override args = {
-    spaceId: Args.string({
-      description: "Space ID to subscribe to members for",
+    space: Args.string({
+      description: "Space to subscribe to members for",
       required: true,
     }),
   };
@@ -86,7 +86,7 @@ export default class SpacesMembersSubscribe extends SpacesBaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SpacesMembersSubscribe);
-    const { spaceId } = args;
+    const { space: spaceName } = args;
 
     // Keep track of the last event we've seen for each client to avoid duplicates
     const lastSeenEvents = new Map<
@@ -101,7 +101,7 @@ export default class SpacesMembersSubscribe extends SpacesBaseCommand {
       }
 
       // Create Spaces client using setupSpacesClient
-      const setupResult = await this.setupSpacesClient(flags, spaceId);
+      const setupResult = await this.setupSpacesClient(flags, spaceName);
       this.realtimeClient = setupResult.realtimeClient;
       this.spacesClient = setupResult.spacesClient;
       this.space = setupResult.space;
@@ -120,13 +120,13 @@ export default class SpacesMembersSubscribe extends SpacesBaseCommand {
         flags,
         "spaces",
         "gettingSpace",
-        `Getting space: ${spaceId}...`,
+        `Getting space: ${spaceName}...`,
       );
       this.logCliEvent(
         flags,
         "spaces",
         "gotSpace",
-        `Successfully got space handle: ${spaceId}`,
+        `Successfully got space handle: ${spaceName}`,
       );
 
       // Enter the space to subscribe
@@ -182,7 +182,7 @@ export default class SpacesMembersSubscribe extends SpacesBaseCommand {
           this.formatJsonOutput(
             {
               members: initialMembers,
-              spaceId,
+              spaceName,
               status: "connected",
               success: true,
             },
@@ -285,7 +285,7 @@ export default class SpacesMembersSubscribe extends SpacesBaseCommand {
             isConnected: member.isConnected,
             profileData: member.profileData,
           },
-          spaceId,
+          spaceName,
           timestamp,
           type: "member_update",
         };

--- a/test/integration/commands/spaces.test.ts
+++ b/test/integration/commands/spaces.test.ts
@@ -351,7 +351,7 @@ describe('Spaces integration tests', function() {
         .it('outputs JSON result', ctx => {
           const output = JSON.parse(ctx.stdout);
           expect(output).to.have.property('success', true);
-          expect(output).to.have.property('spaceId', testSpaceId);
+          expect(output).to.have.property('space', testSpaceId);
         });
     });
 

--- a/test/unit/commands/spaces/spaces.test.ts
+++ b/test/unit/commands/spaces/spaces.test.ts
@@ -206,7 +206,7 @@ describe("spaces commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { spaceId: "test-space" },
+        args: { space: "test-space" },
         argv: [],
         raw: [],
       });
@@ -241,7 +241,7 @@ describe("spaces commands", function () {
     it("should handle profile data when entering", async function () {
       command.setParseResult({
         flags: { profile: '{"name": "Test User", "role": "admin"}' },
-        args: { spaceId: "test-space" },
+        args: { space: "test-space" },
         argv: [],
         raw: [],
       });
@@ -290,7 +290,7 @@ describe("spaces commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { spaceId: "test-space" },
+        args: { space: "test-space" },
         argv: [],
         raw: [],
       });
@@ -349,7 +349,7 @@ describe("spaces commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { spaceId: "test-space" },
+        args: { space: "test-space" },
         argv: [],
         raw: [],
       });
@@ -358,7 +358,7 @@ describe("spaces commands", function () {
     it("should set location data", async function () {
       command.setParseResult({
         flags: { location: '{"x": 100, "y": 200, "page": "dashboard"}' },
-        args: { spaceId: "test-space" },
+        args: { space: "test-space" },
         argv: [],
         raw: [],
       });
@@ -404,7 +404,7 @@ describe("spaces commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { spaceId: "test-space", lockId: "test-lock" },
+        args: { space: "test-space", lockId: "test-lock" },
         argv: [],
         raw: [],
       });
@@ -420,7 +420,7 @@ describe("spaces commands", function () {
     it("should handle lock attributes", async function () {
       command.setParseResult({
         flags: { attributes: '{"priority": "high", "timeout": 5000}' },
-        args: { spaceId: "test-space", lockId: "test-lock" },
+        args: { space: "test-space", lockId: "test-lock" },
         argv: [],
         raw: [],
       });
@@ -466,7 +466,7 @@ describe("spaces commands", function () {
 
       command.setParseResult({
         flags: {},
-        args: { spaceId: "test-space" },
+        args: { space: "test-space" },
         argv: [],
         raw: [],
       });
@@ -475,7 +475,7 @@ describe("spaces commands", function () {
     it("should set cursor position", async function () {
       command.setParseResult({
         flags: { position: '{"x": 150, "y": 250}' },
-        args: { spaceId: "test-space" },
+        args: { space: "test-space" },
         argv: [],
         raw: [],
       });
@@ -493,7 +493,7 @@ describe("spaces commands", function () {
           position: '{"x": 150, "y": 250}',
           data: '{"color": "red", "size": "large"}'
         },
-        args: { spaceId: "test-space" },
+        args: { space: "test-space" },
         argv: [],
         raw: [],
       });


### PR DESCRIPTION
This PR replaces all occurrences of `spaceId` from Ably Spaces commands.

Anything exposed to end-users should now use `space`, or `SPACE`. Internally, there is also use of `spaceName` which is the correct name of the property.

This is similar to what was done for Ably Chat in https://github.com/ably/ably-cli/pull/91. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed CLI argument from “spaceId” to “space” across Spaces commands (cursors, locations, locks, members), including get, get-all, set, subscribe, acquire, get, and enter operations. Output and logs now reference “space” consistently.

- Documentation
  - Updated README command examples, headings, and argument descriptions to use “SPACE” instead of “SPACEID”.

- Tests
  - Adjusted unit and integration tests to expect “space” in arguments and JSON outputs.

Note: This is a user-facing rename and may require updating existing scripts and command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->